### PR TITLE
HPCC-19201 Request projected records from dafileserv

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldDef.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldDef.java
@@ -30,6 +30,7 @@ public class FieldDef implements Serializable {
   private int len;
   private int childLen;
   private boolean fixedLength;
+  private int flags;
   //
   private static final String FieldNameName = "name";
   private static final String FieldTypeName = "type";
@@ -44,6 +45,7 @@ public class FieldDef implements Serializable {
     this.len = 0;
     this.childLen = 0;
     this.fixedLength = false;
+    this.flags = 0;
   }
   /**
    * @param fieldName the name for the field or set or structure
@@ -254,25 +256,66 @@ public class FieldDef implements Serializable {
    * @return the FieldDef object
    */
   public FieldDef getDef(int ndx) { return this.defs[ndx]; }
+
   /**
    * An iterator to walk though the type definitions that compose
    * this type.
    * @return an iterator returning FieldDef objects
    */
-  public Iterator<FieldDef> getDefinitions() {
-    final FieldDef[] defRef = this.defs;
-    Iterator<FieldDef> rslt = new Iterator<FieldDef>() {
+  public Iterator<FieldDef> getDefinitions()
+  {
+    return createDefIterator(defs);
+  }
+  /**
+   * An iterator to walk though the type definitions filtered by projected list.
+   * @return an iterator returning FieldDef objects
+   */
+  public Iterator<FieldDef> getDefinitions(String [] projectedlist/*this should be a map*/)
+  {
+    if (projectedlist != null && projectedlist.length != 0)
+    {
+        FieldDef [] projected = new FieldDef [projectedlist.length];
+
+        int filteredIndex = 0;
+        for(FieldDef fieldDefinition : defs)
+        {
+            boolean included = false;
+            for (String projectedfield : projectedlist)
+            {
+                if (fieldDefinition.getFieldName().equals(projectedfield))
+                {
+                    included = true;
+                    break;
+                }
+            }
+            if (included)
+                projected[filteredIndex++] = fieldDefinition;
+        }
+        return createDefIterator(projected);
+    }
+    else
+      return createDefIterator(defs);
+  }
+
+  public Iterator<FieldDef> createDefIterator(FieldDef[] thedefs)
+  {
+    final FieldDef[] defRef = thedefs;
+    Iterator<FieldDef> rslt = new Iterator<FieldDef>()
+    {
       int pos = 0;
       FieldDef[] copy = defRef;
-      public boolean hasNext() {
+      public boolean hasNext()
+      {
         return (pos<copy.length)  ? true  : false;
       }
-      public FieldDef next() {
+      public FieldDef next()
+      {
         return copy[pos++];
       }
     };
     return rslt;
   }
+
   /**
    * Pick up a field definition from the JSON record definiton string.
    * The definitions are objects in the fields JSON array pair.  The
@@ -310,6 +353,7 @@ public class FieldDef implements Serializable {
       if (FieldTypeName.equals(curr.getName())) {
         typeName = curr.getString();
       }
+      //do we care about xpath and / or flags?
       curr = toks_iter.next();
     }
     if (!toks_iter.hasNext()) {
@@ -328,5 +372,16 @@ public class FieldDef implements Serializable {
     TypeDef typ = type_dict.get(typeName);
     FieldDef rslt = new FieldDef(fieldName, typ);
     return rslt;
+  }
+
+  public String toJSON()
+  {
+      String json;
+
+      json ="{\n\t\"name\":\t\"" + this.fieldName + "\",\n" +
+              //"\t\"type\":\t\"" + this.typeName + "\"\n}" +
+              "\t\"type\":\t\"" + "ty1" + "\"," +
+              "\t\"flags\":\t2\n}";
+      return json;
   }
 }

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
@@ -215,8 +215,9 @@ public class PlainConnection {
     sb.append("{\n \"kind\" : \"diskread\",\n \"fileName\" : \"");
     sb.append(this.filePart.getFilename());
     sb.append("\",\n \"input\" : ");
-    sb.append(this.recDef.getJsonInputDef());
+    sb.append(this.recDef.getJsonInputDef()); //declared DFU file definition
     sb.append(", \n \"output\" : ");
+    //sb.append("\"ty1\": {  \"fieldType\": 2,  \"length\": 4 }, \"fieldType\": 13, \"length\": 20, \"fields\": [  {   \"name\": \"sepal_length\",   \"type\": \"ty1\",   \"flags\": 2  },  {   \"name\": \"sepal_width\",   \"type\": \"ty1\",   \"flags\": 2  },  {   \"name\": \"petal_length\",   \"type\": \"ty1\",   \"flags\": 2  },  {   \"name\": \"petal_width\",   \"type\": \"ty1\",   \"flags\": 2  } ]}");
     sb.append(this.recDef.getJsonOutputDef());
     sb.append("\n }  }\n\n");
     return sb.toString();

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/TypeDef.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/TypeDef.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 import org.hpccsystems.spark.FieldType;
+import org.omg.CORBA.TypeCode;
 
 import java.util.ArrayList;
 import java.io.Serializable;
@@ -22,6 +23,7 @@ public class TypeDef implements Serializable {
   private int childLen;
   private FieldType childType;
   private HpccSrcType childSrc;
+  private short typeCode;
   // flag values from eclhelper.hpp RtlFieldTypeMask enum definition
   final private static short flag_unsigned = 256;
   final private static short flag_unknownsize = 1024;
@@ -77,15 +79,16 @@ public class TypeDef implements Serializable {
   public TypeDef(long type_id, String typeName, int len,
       FieldType childType, int childLen, HpccSrcType childSrc,
       FieldDef[] defs) {
-    short type = (type_id < 10000) ? (short) type_id   : -1;
+    //short type = (type_id < 10000) ? (short) type_id   : -1;
+    typeCode = (type_id < 10000) ? (short) type_id   : -1;
     this.typeName = typeName;
     this.len = len;
     this.struct = defs;
-    this.unsignedFlag = type==type_uint;
+    this.unsignedFlag = typeCode==type_uint;
     this.childLen = childLen;
     this.childSrc = childSrc;
     this.childType = childType;
-    switch (type) {
+    switch (typeCode) {
       case type_boolean:
         this.fixedLength = true;
         this.type = FieldType.BOOLEAN;
@@ -167,7 +170,7 @@ public class TypeDef implements Serializable {
         this.fixedLength = false;
         this.type = FieldType.MISSING;
     }
-    switch (type) {
+    switch (typeCode) {
       case type_int:
       case type_uint:
       case type_real:
@@ -340,5 +343,12 @@ public class TypeDef implements Serializable {
     TypeDef rslt = new TypeDef(fieldType, typeName, length, childType,
         childLen, childSrc, fields);
     return rslt;
+  }
+
+  public String toJSON()
+  {
+    StringBuilder json = new StringBuilder();
+    json.append("\"").append(getTypeName()).append("\": { \"fieldType\": " + typeCode + ", \"length\": " + getLength() + " } ");
+    return json.toString();
   }
 }

--- a/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
@@ -63,12 +63,15 @@ public class DataframeTest {
     System.out.print("Base IP or empty: ");
     System.out.flush();
     String base_ip = br.readLine();
+    System.out.print("Project list (comma delimited): ");
+    System.out.flush();
+    String projectList = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();

--- a/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
@@ -39,12 +39,16 @@ public class HpccFileTest {
     System.out.print("Base IP or empty: ");
     System.out.flush();
     String base_ip = br.readLine();
+    System.out.print("Project list (comma delimited): ");
+    System.out.flush();
+    String projectList = br.readLine();
+
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RDDTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RDDTest.java
@@ -36,7 +36,7 @@ public class RDDTest {
     System.out.flush();
     String sparkHome = br.readLine();
     conf.setSparkHome(sparkHome);
-    System.out.print("Fiull path to JAPI jar: ");
+    System.out.print("Full path to JAPI jar: ");
     System.out.flush();
     String japi_jar = br.readLine();
     System.out.print("Full path to Spark-HPCC jar: ");
@@ -74,12 +74,15 @@ public class RDDTest {
     System.out.print("Base IP or empty: ");
     System.out.flush();
     String base_ip = br.readLine();
+    System.out.print("Project list (comma delimited): ");
+    System.out.flush();
+    String projectList = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,projectList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
@@ -24,6 +24,9 @@ public class RecordTest {
     System.out.print("Enter file name: ");
     System.out.flush();
     String testName = br.readLine();
+    //String testName = "~thor::test::iris";
+    //String testName = "~thor::jdh::japi_test1";
+
     System.out.print("User id: ");
     System.out.flush();
     String user = br.readLine();
@@ -36,12 +39,16 @@ public class RecordTest {
     System.out.print("Base IP or empty: ");
     System.out.flush();
     String base_ip = br.readLine();
+    System.out.print("Project list (comma delimited): ");
+    System.out.flush();
+    String projectList = br.readLine();
+
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, projectList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();
@@ -54,7 +61,7 @@ public class RecordTest {
     System.out.println("Getting record definition");
     RecordDef rd = hpcc.getRecordDefinition();
     FieldDef root_def = rd.getRootDef();
-    Iterator<FieldDef> iter = root_def.getDefinitions();
+    Iterator<FieldDef> iter = root_def.getDefinitions(rd.getProjectedList());
     while (iter.hasNext()) {
       FieldDef field = iter.next();
       System.out.println(field.toString());


### PR DESCRIPTION
WORK IN PROGRESS...

- Adds projected field option
- Create output JSON string in same pass as recdef parse
- RecordDef keep projected list and pre-formated output JSON string
- FieldDef provides new getdefs method with included fields option
- BinaryRecordReader attempst to map projected def to read blocks

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>