### PR TITLE
HPCC-19611 Compressed file read

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/FilePart.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/FilePart.java
@@ -47,12 +47,11 @@ public class FilePart implements Partition, Serializable {
   private FilePart(String ip0, String ipx, String dir, String name,
       int this_part, int num_parts, long part_size, String mask,
       int clear, int ssl, boolean compressed_flag) {
-    String p_str = Integer.toString(this_part);
-    String n_str = Integer.toString(num_parts);
     String f_str = dir + "/" + mask;
     this.primary_ip = ip0;
     this.secondary_ip = ipx;
-    this.file_name = f_str.replace("$P$", p_str).replace("$N$", n_str);
+    this.file_name = f_str.replace("$P$", Integer.toString(this_part))
+                          .replace("$N$", Integer.toString(num_parts));
     this.this_part = this_part;
     this.num_parts = num_parts;
     this.part_size = part_size;

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccFile.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccFile.java
@@ -72,7 +72,7 @@ public class HpccFile implements Serializable {
       ClusterRemapper cr = ClusterRemapper.makeMapper(remap_info, dfu_parts,
           fd.getNumParts());
       this.parts = FilePart.makeFileParts(fd.getNumParts(), fd.getDir(),
-          fd.getFilename(), fd.getPathMask(), dfu_parts, cr);
+          fd.getFilename(), fd.getPathMask(), dfu_parts, cr, fd.getIsCompressed());
       String record_def_json = fd.getJsonInfo();
       if (record_def_json==null) {
         throw new UnusableDataDefinitionException("Definiiton returned was null");

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
@@ -214,7 +214,9 @@ public class PlainConnection {
     sb.append("{ \"format\" : \"binary\", \"node\" : ");
     sb.append("{\n \"kind\" : \"diskread\",\n \"fileName\" : \"");
     sb.append(this.filePart.getFilename());
-    sb.append("\",\n \"input\" : ");
+    sb.append("\", \n  \"compressed\": \"");
+    sb.append((this.filePart.isCompressed()) ?"true"  :"false");
+    sb.append("\", \n \"input\" : ");
     sb.append(this.recDef.getJsonInputDef());
     sb.append(", \n \"output\" : ");
     sb.append(this.recDef.getJsonOutputDef());
@@ -246,9 +248,9 @@ public class PlainConnection {
     sb.append(" \n \"node\" : ");
     sb.append("{\n \"kind\" : \"diskread\",\n \"fileName\" : \"");
     sb.append(this.filePart.getFilename());
-    sb.append("\", \n");
-    if (this.filePart.isCompressed()) sb.append(" \"compressed\": \"true\", ");
-    sb.append(" \"input\" : ");
+    sb.append("\", \n  \"compressed\": \"");
+    sb.append((this.filePart.isCompressed()) ?"true"  :"false");
+    sb.append("\", \n \"input\" : ");
     sb.append(this.recDef.getJsonInputDef());
     sb.append(", \n \"output\" : ");
     sb.append(this.recDef.getJsonOutputDef());

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
@@ -246,7 +246,9 @@ public class PlainConnection {
     sb.append(" \n \"node\" : ");
     sb.append("{\n \"kind\" : \"diskread\",\n \"fileName\" : \"");
     sb.append(this.filePart.getFilename());
-    sb.append("\",\n \"input\" : ");
+    sb.append("\", \n");
+    if (this.filePart.isCompressed()) sb.append(" \"compressed\": \"true\", ");
+    sb.append(" \"input\" : ");
     sb.append(this.recDef.getJsonInputDef());
     sb.append(", \n \"output\" : ");
     sb.append(this.recDef.getJsonOutputDef());
@@ -285,8 +287,8 @@ public class PlainConnection {
       if (len == 0) return 0;
       byte flag = dis.readByte();
       if (flag==hyphen[0]) {
-        if (len<5) throw new HpccFileException("Failed with no message sent");
-        int msgLen = dis.readInt();
+        if (len<2) throw new HpccFileException("Failed with no message sent");
+        int msgLen = len-1;
         byte[] msg = new byte[msgLen];
         this.dis.read(msg);
         String message = new String(msg, hpccSet);


### PR DESCRIPTION
HpccFile changed to get compressed flag from the DFUFileDetail and pass on to FilePart constructor.

FilePart changed to carry compressed flag and to change file parts place holder to number of parts (HPCC-19619).

PlainConnection changed to process error message strings without length prefix; and to add compredded flag to json request string.

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>