### PR TITLE
HPCC-19758 Provide copyright header and cleanup

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/BinaryContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/BinaryContent.java
@@ -1,15 +1,30 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
+
 import javax.xml.bind.DatatypeConverter;
-import org.hpccsystems.spark.thor.FieldDef;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.BinaryType;
+import org.hpccsystems.spark.thor.FieldDef;
 
 /**
  * Binary field content.  Either a DATA field or a DATAn fixed length field.
- * @author holtjd
  *
  */
 public class BinaryContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/BinarySeqContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/BinarySeqContent.java
@@ -1,15 +1,32 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
-import javax.xml.bind.DatatypeConverter;
-import org.hpccsystems.spark.thor.FieldDef;
-import scala.collection.JavaConverters;
 import java.util.ArrayList;
+
+import javax.xml.bind.DatatypeConverter;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
+import org.hpccsystems.spark.thor.FieldDef;
+
+import scala.collection.JavaConverters;
 
 /**
- * @author holtjd
  * A sequence of binary objects, like SET OF DATA in ECL.
  */
 public class BinarySeqContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/BooleanContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/BooleanContent.java
@@ -1,13 +1,28 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
-import org.apache.spark.sql.types.DataTypes;
+
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
 
 /**
  * Contains a Boolean value.
- * @author holtjd
  *
  */
 public class BooleanContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/BooleanSeqContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/BooleanSeqContent.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
@@ -9,7 +25,6 @@ import org.hpccsystems.spark.thor.FieldDef;
 import scala.collection.JavaConverters;
 
 /**
- * @author holtjd
  * A sequence of boolean values
  */
 public class BooleanSeqContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/Content.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/Content.java
@@ -1,6 +1,22 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
+
 import org.apache.spark.sql.types.DataType;
 import org.hpccsystems.spark.thor.FieldDef;
 
@@ -14,7 +30,6 @@ import org.hpccsystems.spark.thor.FieldDef;
  * Each instance type will use the corresponding Java primitive type wrappers
  * to create a string version for the asString and asStringArray methods.
  *
- * @author holtjd
  *
  */
 public abstract class Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/FieldType.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/FieldType.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 /**
  *
  */
@@ -7,8 +22,6 @@ import java.io.Serializable;
 
 /**
  * The data types for data fields on an HPCC record.
- *
- * @author holtjd
  *
  */
 public enum FieldType implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/FilePart.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/FilePart.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 /**
  *
  */
@@ -6,15 +21,15 @@ package org.hpccsystems.spark;
 import java.io.Serializable;
 import java.text.NumberFormat;
 import java.text.ParseException;
-import java.util.Comparator;
 import java.util.Arrays;
+import java.util.Comparator;
+
 import org.apache.spark.Partition;
-import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 import org.hpccsystems.spark.thor.ClusterRemapper;
+import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 
 /**
  * A file part of an HPCC file.  This is the Spark partition for the RDD.
- * @author holtjd
  *
  */
 public class FilePart implements Partition, Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccDataframeFactory.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccDataframeFactory.java
@@ -1,14 +1,29 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.function.Function;
 import java.io.Serializable;
 
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
 /**
- * @author holtjd
  *
  */
 public class HpccDataframeFactory implements Serializable{

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccFile.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccFile.java
@@ -1,23 +1,38 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
-import org.hpccsystems.spark.thor.UnusableDataDefinitionException;
+import java.io.Serializable;
+
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.hpccsystems.spark.thor.ClusterRemapper;
 import org.hpccsystems.spark.thor.RemapInfo;
+import org.hpccsystems.spark.thor.UnusableDataDefinitionException;
 import org.hpccsystems.ws.client.HPCCWsDFUClient;
 import org.hpccsystems.ws.client.platform.DFUFileDetailInfo;
-import org.hpccsystems.ws.client.platform.DFUFilePartsOnClusterInfo;
 import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
+import org.hpccsystems.ws.client.platform.DFUFilePartsOnClusterInfo;
 import org.hpccsystems.ws.client.utils.Connection;
-import java.io.Serializable;
-import org.apache.spark.SparkContext;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.Dataset;
 
 /**
  * Access to file content on a collection of one or more HPCC
  * clusters.
- * @author holtjd
  *
  */
 public class HpccFile implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccFileException.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccFileException.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 /**
  *
  */
@@ -6,7 +21,6 @@ package org.hpccsystems.spark;
 import java.io.Serializable;
 
 /**
- * @author holtjd
  * Exception class for problems accessing files on an HPCC Cluster.
  */
 public class HpccFileException extends Exception implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccRDD.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccRDD.java
@@ -1,28 +1,43 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.util.Iterator;
+
 import org.apache.spark.Dependency;
+import org.apache.spark.InterruptibleIterator;
 import org.apache.spark.Partition;
 import org.apache.spark.SparkContext;
 import org.apache.spark.TaskContext;
-import org.apache.spark.rdd.RDD;
-import org.apache.spark.mllib.regression.LabeledPoint;
-import org.apache.spark.mllib.linalg.Vector;
-import org.hpccsystems.spark.HpccRemoteFileReader;
-import org.apache.spark.InterruptibleIterator;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.regression.LabeledPoint;
+import org.apache.spark.rdd.RDD;
+
+import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.mutable.ArraySeq;
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
-import scala.collection.JavaConverters;
 
 
 /**
  * The implementation of the RDD<Record> (an RDD of type Record data) class.
- * @author holtjd
  *
  */
 public class HpccRDD extends RDD<Record> implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccRemoteFileReader.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccRemoteFileReader.java
@@ -1,11 +1,24 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
-import org.hpccsystems.spark.HpccFileException;
 import org.hpccsystems.spark.thor.BinaryRecordReader;
 
 
 /**
- * @author holtjd
  * Remote file reader used by the HpccRDD.
  */
 public class HpccRemoteFileReader {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccRow.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccRow.java
@@ -1,18 +1,35 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.ArrayList;
+
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructType;
-import scala.collection.Seq;
-import scala.collection.JavaConverters;
+
 import scala.Tuple2;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
 
 public class HpccRow implements Row, Serializable {
   static private final long serialVersionUID = 1L;

--- a/DataAccess/src/main/java/org/hpccsystems/spark/IntegerContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/IntegerContent.java
@@ -1,8 +1,24 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
-import org.apache.spark.sql.types.DataTypes;
+
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
 
 public class IntegerContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/IntegerSeqContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/IntegerSeqContent.java
@@ -1,14 +1,30 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import scala.collection.JavaConverters;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
 
+import scala.collection.JavaConverters;
+
 /**
- * @author holtjd
  * Content for SET OF INTEGER or SET OF UNSIGNED
  */
 public class IntegerSeqContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/RealContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/RealContent.java
@@ -1,6 +1,22 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;

--- a/DataAccess/src/main/java/org/hpccsystems/spark/RealSeqContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/RealSeqContent.java
@@ -1,14 +1,30 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import scala.collection.JavaConverters;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
 
+import scala.collection.JavaConverters;
+
 /**
- * @author holtjd
  * A set or array of real values.
  */
 public class RealSeqContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/Record.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/Record.java
@@ -1,19 +1,31 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
-import org.apache.spark.mllib.regression.LabeledPoint;
-import org.apache.spark.mllib.linalg.Vectors;
 import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+import org.apache.spark.mllib.regression.LabeledPoint;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.DataType;
-import java.util.ArrayList;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * A data record from the HPCC system.  A collection of fields, accessed by
  * name or as an enumeration.
  *
- * @author holtjd
  *
  */
 public class Record implements java.io.Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/RecordContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/RecordContent.java
@@ -1,13 +1,28 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
+
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
 import org.hpccsystems.spark.thor.FieldDef;
 
 /**
- * @author holtjd
  * The row content, an group of Content objects.
  */
 public class RecordContent extends Content implements Serializable{

--- a/DataAccess/src/main/java/org/hpccsystems/spark/RecordDef.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/RecordDef.java
@@ -1,10 +1,28 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.hpccsystems.spark.thor.DefToken;
 import org.hpccsystems.spark.thor.FieldDef;
 import org.hpccsystems.spark.thor.HpccSrcType;
@@ -14,16 +32,9 @@ import org.hpccsystems.spark.thor.UnusableDataDefinitionException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonToken;
 
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.DataType;
-
 /**
  * HPCC record definition.  Includes HPCC record info strings and derived
  * Field Defs.
- * @author holtjd
  *
  */
 public class RecordDef implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/RecordSeqContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/RecordSeqContent.java
@@ -1,16 +1,32 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import scala.collection.JavaConverters;
+
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import org.hpccsystems.spark.thor.FieldDef;
 
+import scala.collection.JavaConverters;
+
 /**
- * @author holtjd
  *
  */
 public class RecordSeqContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/StringContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/StringContent.java
@@ -1,13 +1,28 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark;
 
 import java.io.Serializable;
-import org.apache.spark.sql.types.DataTypes;
+
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
 
 /**
  * A field content item with String as the native type.
- * @author holtjd
  *
  */
 public class StringContent extends Content implements Serializable {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/StringSeqContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/StringSeqContent.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 /**
  *
  */
@@ -5,13 +20,14 @@ package org.hpccsystems.spark;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import scala.collection.JavaConverters;
+
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.hpccsystems.spark.thor.FieldDef;
 
+import scala.collection.JavaConverters;
+
 /**
- * @author holtjd
  *
  */
 public class StringSeqContent extends Content implements Serializable{

--- a/DataAccess/src/main/java/org/hpccsystems/spark/package-info.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/package-info.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 /**
  * Spark access to data residing in an HPCC environment.
  * The JAPI class library from HPCCSystems is used to used to access
@@ -16,8 +31,6 @@
  * <li>HpccRemoteFileReader is the facade for the type of file reader.</li>
  * <li>Record is the container class holding the data for a record from THOR.</li>
  * </ul>
- *
- * @author holtjd
  *
  */
 package org.hpccsystems.spark;

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/AddrRemapper.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/AddrRemapper.java
@@ -1,16 +1,31 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
-import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
-import org.hpccsystems.spark.HpccFileException;
-import java.util.HashMap;
-import java.util.Comparator;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.StringTokenizer;
+
+import org.hpccsystems.spark.HpccFileException;
+import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 
 /**
  * Map internal IP addresses to external IP addresses.  Note that the
  * relation of parts to IP address must be in lexical order.
- * @author holtjd
  *
  */
 public class AddrRemapper extends ClusterRemapper {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/BinaryRecordReader.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/BinaryRecordReader.java
@@ -1,30 +1,45 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
-import java.util.NoSuchElementException;
-import java.util.Iterator;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.nio.charset.Charset;
-import org.hpccsystems.spark.HpccFileException;
-import org.hpccsystems.spark.Record;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.hpccsystems.spark.BinaryContent;
+import org.hpccsystems.spark.BinarySeqContent;
+import org.hpccsystems.spark.BooleanContent;
+import org.hpccsystems.spark.BooleanSeqContent;
 import org.hpccsystems.spark.Content;
 import org.hpccsystems.spark.FilePart;
+import org.hpccsystems.spark.HpccFileException;
+import org.hpccsystems.spark.IntegerContent;
+import org.hpccsystems.spark.IntegerSeqContent;
+import org.hpccsystems.spark.RealContent;
+import org.hpccsystems.spark.RealSeqContent;
+import org.hpccsystems.spark.Record;
 import org.hpccsystems.spark.RecordContent;
 import org.hpccsystems.spark.RecordDef;
-import org.hpccsystems.spark.IntegerContent;
-import org.hpccsystems.spark.RealContent;
-import org.hpccsystems.spark.BinaryContent;
-import org.hpccsystems.spark.BooleanContent;
-import org.hpccsystems.spark.StringContent;
-import org.hpccsystems.spark.IntegerSeqContent;
-import org.hpccsystems.spark.RealSeqContent;
-import org.hpccsystems.spark.BooleanSeqContent;
-import org.hpccsystems.spark.BinarySeqContent;
-import org.hpccsystems.spark.StringSeqContent;
 import org.hpccsystems.spark.RecordSeqContent;
+import org.hpccsystems.spark.StringContent;
+import org.hpccsystems.spark.StringSeqContent;
 
 /**
- * @author holtjd
  * Reads HPCC Cluster data in binary format.
  */
 public class BinaryRecordReader implements IRecordReader {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/ClusterRemapper.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/ClusterRemapper.java
@@ -1,11 +1,24 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
-import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
-import java.util.Comparator;
 import org.hpccsystems.spark.HpccFileException;
+import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 
 /**
- * @author holtjd
  * Re-map address information for Clusters that can
  * only be reached through alias addresses.
  * Addresses are re-mapped to a range of IP addresses or to an

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefToken.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefToken.java
@@ -1,15 +1,30 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonLocation;
-import java.util.Deque;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Enumeration;
+import java.util.Deque;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 
 public class DefToken {
   private final JsonToken tok;

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldDef.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldDef.java
@@ -1,21 +1,35 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
-import org.hpccsystems.spark.FieldType;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.DataType;
-import com.fasterxml.jackson.core.JsonToken;
-
 import java.io.Serializable;
-import java.util.Iterator;
 import java.util.HashMap;
+import java.util.Iterator;
+
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.hpccsystems.spark.FieldType;
+
+import com.fasterxml.jackson.core.JsonToken;
 
 /**
  * The name and field type for an item from the HPCC environment.  The
  * types may be single scalar types or may be arrays or structures.
- *
- * @author holtjd
  *
  */
 

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/HpccSrcType.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/HpccSrcType.java
@@ -1,7 +1,21 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 /**
- * @author holtjd
  * The type of the binary source data.
  */
 public enum HpccSrcType {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/IRecordReader.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/IRecordReader.java
@@ -1,10 +1,24 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 import org.hpccsystems.spark.HpccFileException;
 import org.hpccsystems.spark.Record;
 
 /**
- * @author holtjd
  * Interface for the HPCC Systems remote file readers.
  */
 public interface IRecordReader {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/NullRemapper.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/NullRemapper.java
@@ -1,10 +1,24 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
-import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 import org.hpccsystems.spark.HpccFileException;
+import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 
 /**
- * @author holtjd
  * A no action re-map of the address.  Does provide the port information.
  */
 public class NullRemapper extends ClusterRemapper {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/ParsedContent.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/ParsedContent.java
@@ -1,9 +1,23 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 import org.hpccsystems.spark.Content;
 
 /**
- * @author holtjd
  * Container for parsing holding the content object and the items
  * consumed.
  */

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 import java.io.IOException;
@@ -8,7 +23,6 @@ import org.hpccsystems.spark.HpccFileException;
 import org.hpccsystems.spark.RecordDef;
 
 /**
- * @author holtjd
  * The connection to a specific THOR node for a specific file part.
  *
  */

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PortRemapper.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PortRemapper.java
@@ -1,13 +1,27 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 /**
  *
  */
 package org.hpccsystems.spark.thor;
 
-import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 import org.hpccsystems.spark.HpccFileException;
+import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
 
 /**
- * @author holtjd
  * Re-maps addresses to a single IP and a range of ports.  Used when the THOR
  * cluster is on a virtual network and ports on a host in this network have
  * been aliased to the addresses on the virtual network.

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/RemapInfo.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/RemapInfo.java
@@ -1,9 +1,23 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 import java.io.Serializable;
 
 /**
- * @author holtjd
  * Information to re-map address information for Clusters that can
  * only be reached through alias addresses.
  * Addresses are re-mapped to a range of IP addresses or to an

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/TypeDef.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/TypeDef.java
@@ -1,12 +1,26 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 
 import org.hpccsystems.spark.FieldType;
-
-import java.util.ArrayList;
-import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonToken;
 

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/UnparsableContentException.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/UnparsableContentException.java
@@ -1,7 +1,21 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 /**
- * @author holtjd
  * The data block from the HPCC Cluster held unexpected values
  * and could not be parsed successfully.
  */

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/UnusableDataDefinitionException.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/UnusableDataDefinitionException.java
@@ -1,7 +1,21 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.spark.thor;
 
 /**
- * @author holtjd
  * This exception is thrown with the data definition cannot be
  * used to retrieve or describe the data.  The caller will need
  * to use a different file.

--- a/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
@@ -1,16 +1,18 @@
 package org.hpccsystems.spark;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
 //import scala.collection.mutable.ArraySeq;
 import org.apache.spark.SparkConf;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.Row;
-import org.hpccsystems.spark.thor.RemapInfo;
 import org.apache.spark.sql.Dataset;
-import scala.collection.Seq;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hpccsystems.spark.thor.RemapInfo;
+
 import scala.collection.JavaConverters;
-import java.util.Arrays;
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
+import scala.collection.Seq;
 
 public class DataframeTest {
 

--- a/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
@@ -1,14 +1,14 @@
 package org.hpccsystems.spark;
 
-import java.util.Iterator;
-import java.io.InputStreamReader;
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+
 import org.hpccsystems.spark.thor.FieldDef;
 import org.hpccsystems.spark.thor.RemapInfo;
 
 /**
  * Test the access for information on a distributed file on a THOR cluster.
- * @author John Holt
  *
  */
 public class HpccFileTest {

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RDDTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RDDTest.java
@@ -1,30 +1,30 @@
 package org.hpccsystems.spark;
 
-import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
-import org.apache.spark.rdd.RDD;
-import org.apache.spark.mllib.regression.LabeledPoint;
-import org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS;
-import org.apache.spark.mllib.classification.LogisticRegressionModel;
-import org.apache.spark.mllib.evaluation.MulticlassMetrics;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.function.Function;
-import scala.collection.Seq;
-import scala.collection.JavaConverters;
-import scala.Tuple2;
-import scala.reflect.ClassTag;
-import scala.reflect.ClassTag$;
-import org.hpccsystems.spark.HpccFile;
-import org.hpccsystems.spark.thor.RemapInfo;
-import java.util.Arrays;
-import java.io.InputStreamReader;
 import java.io.BufferedReader;
 //
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.mllib.classification.LogisticRegressionModel;
+import org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS;
+import org.apache.spark.mllib.evaluation.MulticlassMetrics;
+import org.apache.spark.mllib.regression.LabeledPoint;
+import org.apache.spark.rdd.RDD;
+import org.hpccsystems.spark.thor.RemapInfo;
+
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
 
 
 /**
  * Test from to test RDD by reading the data and running Logistic Regression.
- * @author holtjd
  *
  */
 public class RDDTest {

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
@@ -1,12 +1,12 @@
 package org.hpccsystems.spark;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.Iterator;
 
 import org.hpccsystems.spark.thor.BinaryRecordReader;
 import org.hpccsystems.spark.thor.FieldDef;
 import org.hpccsystems.spark.thor.RemapInfo;
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
 
 public class RecordTest {
 


### PR DESCRIPTION
- Adds apache 2 2018 license headers
- Organizes import statements
- Removes author entries

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>