### PR TITLE
HPCC-19201 Support field selection to prune unwanted data

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/ColumnPruner.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/ColumnPruner.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import org.hpccsystems.spark.thor.DefToken;
+import org.hpccsystems.spark.thor.DefEntry;
+import org.hpccsystems.spark.thor.UnusableDataDefinitionException;
+
+/**
+ * Prune columns from the output request format.  The column
+ * selection parameter string is a comma separated list of
+ * field names.  Nested fields are selected with the usual
+ * dot notation (e.g., foo.bar for the bar field in a foo field).
+ * All columns are selected for a structure field when no columns are
+ * specified (e.g., foo where foo is a record type).  Selection column
+ * names that do not exist are ignored.  If the selection string does not
+ * select any column, then all columns are returned.
+ */
+public class ColumnPruner implements Serializable {
+  private final static long serialVersionUID = 1L;
+  private String fieldListString;
+  private boolean allFields;
+  private transient TargetColumn targetContentRoot;
+  /**
+   * Contruct a pruner to remove fields from the output definition of a remote
+   * read definition string.
+   * @param commaSepFieldNamelist a comma separated list of field names.  Nested
+   * fields are expressed using the normal compound name style with a dot (".")
+   * separator.  For example, item1,foo.bar1,foo.bar2,item3, selects the item1,
+   * item3 fields (which may be child datasets) and the bar1 and bar2 fields from
+   * the foo child dataset field.
+   */
+  public ColumnPruner(String commaSepFieldNamelist) {
+    this.fieldListString = commaSepFieldNamelist;
+    this.allFields = "".equals(commaSepFieldNamelist);
+  }
+  /**
+   * Protected constructor for serialization/de-serialization support.
+   */
+  protected ColumnPruner() {
+    this.fieldListString = "";
+    this.allFields = true;
+  }
+  /**
+   * Prune the definition tokens to match the field list.
+   * @param toks the complete set of tokens
+   * @return the revised set with the pruned fields and unused
+   * type information removed.
+   * @exception UnusableDataDefinitionException is thrown when none of the
+   * fields in the selection list are defined.
+   */
+  public DefToken[] pruneDefTokens(DefToken[] toks)
+      throws UnusableDataDefinitionException {
+    if (this.allFields) return toks;
+    if (targetContentRoot==null) prepPruner();
+    // Build a detailed map of the definition tokens
+    DefToken[] rslt = DefEntry.pruneDefTokens(toks, targetContentRoot);
+    return rslt;
+  }
+  /**
+   * Get the TargetColumn for the root structure.
+   * @return root target column container.
+   */
+  public TargetColumn getTargetColumn() {
+    if (this.targetContentRoot==null) prepPruner();
+    return this.targetContentRoot;
+  }
+  //
+  private void prepPruner() {
+    if (this.allFields) return;   // nothing to do
+    String[] compound_names = this.fieldListString.split(",");
+    for (int i=0; i<compound_names.length; i++) {
+      compound_names[i] = compound_names[i].trim().toLowerCase();
+    }
+    Arrays.sort(compound_names);
+    // now break the compound names down
+    String[][] dot_names = new String[compound_names.length][];
+    for (int i=0; i<compound_names.length; i++) {
+      dot_names[i] = compound_names[i].split("\\.");  // pick off levels
+    }
+    this.targetContentRoot = new TargetColumn("");
+    for (int i=0; i<compound_names.length; i++) {
+      TargetColumn cn = this.targetContentRoot.getOrCreateColumnWithName(dot_names[i][0]);
+      for (int j=1; j<dot_names[i].length; j++) {
+        cn = cn.getOrCreateColumnWithName(dot_names[i][j]);
+      }
+    }
+    // root object ready
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccFile.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccFile.java
@@ -50,12 +50,13 @@ public class HpccFile implements Serializable {
    * @param port the ESP port
    * @param user a valid account that has access to the file
    * @param pword a valid pass word for the account
+   * @param targetColumnList a comma separated list of colomn names with dotted names
    * @throws HpccFileException
    */
   public HpccFile(String fileName, String protocol, String host,
-      String port, String user, String pword) throws HpccFileException{
-    this(fileName, protocol, host, port, user, pword,
-         new RemapInfo(0));
+          String port, String user, String pword, String targetColumnList)
+          throws HpccFileException{
+    this(fileName, protocol, host, port, user, pword, targetColumnList, new RemapInfo(0));
   }
   /**
    * Constructor for the HpccFile.  Captures the information
@@ -69,13 +70,16 @@ public class HpccFile implements Serializable {
    * @param port the ESP port
    * @param user a valid account that has access to the file
    * @param pword a valid pass word for the account
+   * @param targetColumnList a comma separated list of column names in dotted
+   * notation for columns within compound columns.
    * @param remap_info address and port re-mapping info for THOR cluster
    * @throws HpccFileException
    */
   public HpccFile(String fileName, String protocol, String host,
-      String port, String user, String pword, RemapInfo remap_info)
-      throws HpccFileException {
+      String port, String user, String pword, String targetColumnList,
+      RemapInfo remap_info) throws HpccFileException {
     this.recordDefinition = new RecordDef();  // missing, the default
+    ColumnPruner cp = new ColumnPruner(targetColumnList);
     Connection conn = new Connection(protocol, host, port);
     conn.setUserName(user);
     conn.setPassword(pword);
@@ -92,7 +96,7 @@ public class HpccFile implements Serializable {
       if (record_def_json==null) {
         throw new UnusableDataDefinitionException("Definiiton returned was null");
       }
-      this.recordDefinition = RecordDef.parseJsonDef(record_def_json);
+      this.recordDefinition = RecordDef.fromJsonDef(record_def_json, cp);
     } catch (UnusableDataDefinitionException e) {
       throw new HpccFileException("Bad definition", e);
     } catch (Exception e) {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/TargetColumn.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/TargetColumn.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+
+/**
+ * A named column, which can have zero or more columns
+ *
+ */
+public class TargetColumn implements Serializable {
+  private final static long serialVersionUID = 1L;
+  private String name;
+  private boolean allColumns;
+  private HashMap<String,TargetColumn> columns;
+  /**
+   * Null constructor for serialization.
+   */
+  protected TargetColumn() {
+    this.name = "";
+    this.allColumns = true;
+    this.columns = null;
+  }
+  /**
+   * Constructor for build process.  A simple column by default.
+   * @param n
+   */
+  public TargetColumn(String n) {
+    this.name = n;
+    this.allColumns = true;
+    this.columns = null;
+  }
+  /**
+   * The column name of this column.
+   * @return the column name
+   */
+  public String getName() { return this.name; }
+  /**
+   * Column has a column with name or is all columns
+   * @param name
+   * @return true when name is known or is all columns
+   */
+  public boolean hasColumnWithName(String name) {
+    return this.allColumns || columns.containsKey(name);
+  }
+  /**
+   * The columns (if any) that make up this column.  Most of the time a
+   * column holds scalar values or arrays of scalar values.  A column can
+   * hold child datasets or a single record.  In this case, there will be
+   * columns that make up this complex column.
+   * @return An array of columns or an empty array if this column is simple.
+   */
+  public TargetColumn[] getColumns() {
+    return (this.allColumns) ? new TargetColumn[0]
+                             : columns.values().toArray(new TargetColumn[0]);
+  }
+  /**
+   * Get the column with this name or create one if this column does not have
+   * a column with the supplied name.
+   * @param name the column name of interest
+   * @return the TargetName object for the named column
+   */
+  public TargetColumn getOrCreateColumnWithName(String name) {
+    if (this.columns==null) {
+      this.allColumns = false;
+      this.columns = new HashMap<String,TargetColumn>();
+    }
+    if (this.columns.containsKey(name)) return this.columns.get(name);
+    TargetColumn cn = new TargetColumn(name);
+    columns.put(name,cn);
+    return cn;
+  }
+  /**
+   * Does this name have selected columns of interest
+   * @return true if this is a simple column or if all columns are targets
+   */
+  public boolean allFields() { return this.allColumns; }
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(this.name);
+    if (!this.allColumns) {
+      sb.append("[");
+      for (TargetColumn col : this.columns.values()) {
+        sb.append(col.toString());
+        sb.append(";");
+      }
+      sb.append("]");
+    }
+    return sb.toString();
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntry.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntry.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.util.ArrayList;
+import java.io.Serializable;
+import org.hpccsystems.spark.TargetColumn;
+import org.hpccsystems.spark.thor.UnusableDataDefinitionException;
+
+/**
+ * Abstract class to map a DefToken sequence.
+ */
+public abstract class DefEntry implements Serializable {
+  static final long serialVersionUID = 1L;
+  public static final String FIELDS = "fields";
+  public static final String CHILD = "child";
+  public static final String NAME = "name";
+  public static final String TYPE = "type";
+  private String name;
+  private int beginPosition;
+  private int endPosition;
+  private int parentPosition;
+  /**
+   * Empty constructor for serialization support.
+   */
+  protected DefEntry() {
+    this.name = "";
+    this.beginPosition = -1;
+    this.endPosition = -1;
+    this.parentPosition = -1;
+  }
+  /**
+   * Normal constructor.  Positions are provided by setter methods.
+   * @param n the name of the object or the empty string if unnamed.
+   * @param begin the first token position
+   * @param end the last token position
+   * @param the parent token position
+   */
+  protected DefEntry(String n, int begin, int end, int parent) {
+    this.name = n;
+    this.beginPosition = begin;
+    this.endPosition = end;
+    this.parentPosition = parent;
+  }
+  /**
+   * Append these possibly revised tokens to the ArrayList.
+   * @param toksNew the ArrayList to be updated
+   * @param toksInput the original tokens
+   */
+  public abstract void toTokens(ArrayList<DefToken> toksNew, DefToken[] toksInput);
+  /**
+   * A readable version of the object
+   * @return the readable information.
+   */
+  public abstract String toString();
+ /**
+   * the object name or the empty string if unnamed
+   * @return the name
+   */
+  public String getName() { return this.name; }
+  /**
+   * Get the ordinal position of the DefToken that begins this object
+   * @return the position
+   */
+  public int getBeginPosition() { return beginPosition; }
+  /**
+   * The ordinal position of the last DefToken for this object.
+   * @return ordinal position of end
+   */
+  public int getEndPosition() { return endPosition; }
+  /**
+   * The parent identifier, an ordinal position of the parent
+   * @return the parent identifier
+   */
+  public int getParent() { return this.parentPosition; }
+  /**
+   * The number of DefToken entries for this DefEntry.
+   * @return the underlying token count
+   */
+  public int getTokenCount() { return this.endPosition-this.beginPosition+1; }
+  /**
+   * Prune the DefToken sequence with the TargetColumn information.
+   * @param toks the source data definition
+   * @param tc the root column definition
+   * @return the pruned sequence of tokens.
+   * @throws UnusableDataDefinitionException when the token sequence is unexpected
+   * or when all of the target columns are not present.
+   */
+  public static DefToken[] pruneDefTokens(DefToken[] toks, TargetColumn tc)
+      throws UnusableDataDefinitionException {
+    if (tc.allFields()) return toks;
+    DefEntryRoot root = new DefEntryRoot(toks);
+    root.countUse(tc);
+    ArrayList<DefToken> work_list = new ArrayList<DefToken>();
+    root.toTokens(work_list, toks);
+    DefToken[] pruned_toks = work_list.toArray(new DefToken[0]);
+    DefToken.renumber(pruned_toks);
+    return pruned_toks;
+  }
+  //
+  protected static int getTokenCount(DefToken[] toks, int startPos)
+      throws UnusableDataDefinitionException {
+    int curr_level = toks[startPos].getLevel();
+    int tokenCount = 1;
+    while (startPos+tokenCount < toks.length
+         && curr_level<toks[startPos+tokenCount].getLevel()) {
+      tokenCount++;
+    }
+    tokenCount++; // count the close
+    if (startPos+tokenCount >= toks.length
+        || !DefToken.pairedTypes(toks[startPos].getToken(),
+                                toks[startPos+tokenCount-1].getToken())) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("No close for ");
+      sb.append(toks[startPos].toString());
+      throw new UnusableDataDefinitionException(sb.toString());
+    }
+    return tokenCount;
+  }
+  protected static boolean hasFields(DefToken[] toks, int startPos, int tokCount) {
+    for (int i=startPos; i<startPos+tokCount; i++) {
+      if (toks[i].getName().equals(FIELDS)) return true;
+    }
+    return false;
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryField.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryField.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.hpccsystems.spark.TargetColumn;
+
+/**
+ * DefEntry for a field in a type with a field list.
+ */
+public class DefEntryField extends DefEntry implements Serializable {
+  static final long serialVersionUID = 1L;
+  private String fieldName;
+  private String typeName;
+  private int used;
+  /**
+   * Empty constructor to support serialization.
+   */
+  protected DefEntryField() {
+  }
+  /**
+   * The DefEntry for objects describing a field.
+   * @param toks the tokens
+   * @param startPos starting position
+   * @param tokCount number of tokens in the sequence
+   * @param parent the parent position
+   */
+  public DefEntryField(DefToken[] toks, int startPos, int tokCount, int parent)
+      throws UnusableDataDefinitionException {
+    super(Integer.toString(startPos), startPos, startPos+tokCount-1, parent);
+    this.fieldName = "";
+    this.typeName = "";
+    for (int i=startPos; i<startPos+tokCount; i++) {
+      if (DefEntry.NAME.equals(toks[i].getName())) {
+        this.fieldName = toks[i].getString();
+      } else if (DefEntry.TYPE.equals(toks[i].getName())) {
+        this.typeName = toks[i].getString();
+      }
+    }
+    if ("".equals(this.fieldName) || "".equals(this.typeName)) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("Unnamed or untyped field at posiiton ");
+      sb.append(startPos);
+      sb.append(" for ");
+      sb.append(tokCount);
+      sb.append(" tokens");
+      throw new UnusableDataDefinitionException(sb.toString());
+    }
+  }
+  /**
+   * The field name associated with the entry.
+   * @return the field name.
+   */
+  public String getFieldName() { return this.fieldName; }
+  /**
+   * Count the use of this type and fields defined by this type and named
+   * (perhaps implicitly) by the TargetColumn filter
+   * @param tc Columns targeted.  If this type has columns and the TargetColumn
+   * has no entries, then all columns are selected.
+   * @param typDict The type dictionary for updating referenced types.
+   */
+  public void countUse(TargetColumn tc, HashMap<String,DefEntryType> typDict)
+      throws UnusableDataDefinitionException {
+    this.used++;
+    if (!typDict.containsKey(this.typeName)) {
+      throw new UnusableDataDefinitionException("Missing type "+this.typeName);
+    }
+    DefEntryType typ = typDict.get(this.typeName);
+    typ.countUse(tc, typDict);
+  }
+  /**
+   * Count the use.  Used when the parent column is marked as all columns.
+   * @param typDict the type dictionary so the types can be marked as used
+   * @throws UnusableDataDefinitionException
+   */
+  public void countUse(HashMap<String,DefEntryType> typDict)
+      throws UnusableDataDefinitionException {
+    this.used++;
+    if (!typDict.containsKey(this.typeName)) {
+      throw new UnusableDataDefinitionException("Missing type "+this.typeName);
+    }
+    DefEntryType typ = typDict.get(this.typeName);
+    typ.countUse(typDict);
+  }
+
+  /* (non-Javadoc)
+   * @see org.hpccsystems.spark.thor.DefEntry#toTokens(java.util.ArrayList)
+   */
+  @Override
+  public void toTokens(ArrayList<DefToken> toksNew, DefToken[] toksInput) {
+    if (this.used==0) return;
+    for (int i=this.getBeginPosition(); i<=this.getEndPosition(); i++) {
+      toksNew.add(toksInput[i]);
+    }
+  }
+  @Override
+  public String toString() {
+    int initialSize = this.fieldName.length()+this.typeName.length()+20;
+    StringBuilder sb = new StringBuilder(initialSize);
+    sb.append(this.fieldName);
+    sb.append("{");
+    sb.append(this.getBeginPosition());
+    sb.append("-");
+    sb.append(this.getEndPosition());
+    sb.append(";");
+    sb.append(this.getTokenCount());
+    sb.append("} of type ");
+    sb.append(this.typeName);
+    sb.append((this.used>0) ? " used" : " unused");
+    return sb.toString();
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryRoot.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryRoot.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.HashMap;
+import org.hpccsystems.spark.TargetColumn;
+
+
+/**
+ * Map of the tokens using object maps.  Prunes as requested.  The map
+ * works without needing detailed knowledge of the makeup of the token
+ * sequence from the JSON file structure definition.  The definition
+ * roughly is a sequence of format definition objects followed by a
+ * definition of the top level record structure.  The record structure
+ * has an array named "fields" as well as some other information.
+ *
+ * Step 1, we want to copy the tokens before the first type definition token,
+ * which is denoted by the last_pre_type field..
+ *
+ * Step 2, we want to copy the tokens associated with each type that is used.
+ *
+ * Step 3, we want to copy the record structure definition tokens after the
+ * last type definition token and before the first field list token.  These
+ * positions are first_post_type and last_pre_fields respectively.
+ *
+ * Step 4, we copy the tokens associated with each field that is used.
+ *
+ * Step 5, we want to copy the tokens after the last field definition token,
+ * which is denoted by first_post_fields.
+ */
+public class DefEntryRoot extends DefEntry implements Serializable {
+  static final long serialVersionUID = 1L;
+  private ArrayList<DefEntryType> types;
+  private HashMap<String,DefEntryType> typeDict;
+  private ArrayList<DefEntryField> fields;
+  private HashMap<String,DefEntryField> fieldDict;
+  private int last_pre_types; // pos of the last token before the first types token
+  private int first_post_type; // pos of the first token after the last types token
+  private int last_pre_fields;  // pos of the last tok bef the first fields tok
+  private int first_post_fields; // pos of the first tok after the last fields tok
+
+  /**
+   * Empty constructor for serialization support.
+   */
+  protected DefEntryRoot() {
+  }
+  /**
+   * @param toks the array of definition tokens
+   */
+  public DefEntryRoot(DefToken[] toks) throws UnusableDataDefinitionException {
+    super("", 0, toks.length-1, -1);
+    this.types = new ArrayList<DefEntryType>();
+    this.typeDict = new HashMap<String,DefEntryType>();
+    this.fields = new ArrayList<DefEntryField>();
+    this.fieldDict = new HashMap<String,DefEntryField>();
+    this.last_pre_types = 0; // assumes only the start precedes the types
+    int curr_pos = 1;
+    int num_tokens = 0;
+    // pick up the type definition objects
+    while (toks[curr_pos].isObjectStart()) {
+      num_tokens = DefEntry.getTokenCount(toks, curr_pos);
+      DefEntryType typ = new DefEntryType(toks, curr_pos, num_tokens, 0);
+      types.add(typ);
+      typeDict.put(typ.getName(), typ);
+      curr_pos += num_tokens;
+    }
+    if (this.types.size()==0) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("No types found.  Current token is ");
+      sb.append(toks[curr_pos].toString());
+      throw new UnusableDataDefinitionException(sb.toString());
+    }
+    // walk past the entries prior to the field list
+    this.first_post_type = curr_pos;
+    while (!toks[curr_pos].isArrayStart()
+          && !DefEntry.FIELDS.equals(toks[curr_pos].getName())) {
+      curr_pos++;
+      if (curr_pos>=this.getEndPosition()) {
+        throw new UnusableDataDefinitionException("Unexpected end looking for list");
+      }
+    }
+    this.last_pre_fields = curr_pos;
+    // pick up the fields
+    curr_pos++;
+    while (toks[curr_pos].isObjectStart()) {
+      num_tokens = DefEntry.getTokenCount(toks, curr_pos);
+      DefEntryField fld = new DefEntryField(toks, curr_pos, num_tokens, 0);
+      this.fields.add(fld);
+      this.fieldDict.put(fld.getFieldName(), fld);
+      curr_pos += num_tokens;
+    }
+    if (!toks[curr_pos].isArrayEnd()) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("Unexpected end, found ");
+      sb.append(toks[curr_pos].toString());
+      throw new UnusableDataDefinitionException(sb.toString());
+    }
+    this.first_post_fields = curr_pos;
+    if (this.fields.size()==0) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("No fields found.");
+      throw new UnusableDataDefinitionException(sb.toString());
+    }
+  }
+  public void countUse(TargetColumn tc) throws UnusableDataDefinitionException {
+    int fieldsUsed = 0;
+    for (TargetColumn col : tc.getColumns()) {
+      if (this.fieldDict.containsKey(col.getName())) {
+        fieldsUsed++;
+        this.fieldDict.get(col.getName()).countUse(col, this.typeDict);
+      }
+    }
+    if (fieldsUsed==0 || tc.allFields()) {
+      for (DefEntryField fld : this.fields) {
+        fld.countUse(this.typeDict);
+      }
+    }
+  }
+  /* (non-Javadoc)
+   * @see org.hpccsystems.spark.thor.DefEntry#toTokens(java.util.ArrayList)
+   */
+  @Override
+  public void toTokens(ArrayList<DefToken> toksNew, DefToken[] toksInput) {
+    for (int i=0; i<=this.last_pre_types; i++) {
+      toksNew.add(toksInput[i]);
+    }
+    Iterator<DefEntryType> typIter = this.types.iterator();
+    while (typIter.hasNext()) {
+      typIter.next().toTokens(toksNew,  toksInput);
+    }
+    for (int i=this.first_post_type; i<=this.last_pre_fields; i++) {
+      toksNew.add(toksInput[i]);
+    }
+    Iterator<DefEntryField> fldIter = this.fields.iterator();
+    while (fldIter.hasNext()) {
+      fldIter.next().toTokens(toksNew, toksInput);
+    }
+    for (int i=this.first_post_fields; i<toksInput.length; i++) {
+      toksNew.add(toksInput[i]);
+    }
+  }
+  @Override
+  public String toString() {
+    int initialSize = 50*(this.getEndPosition()-this.getBeginPosition()+1);
+    StringBuilder sb = new StringBuilder(initialSize);
+    sb.append("{");
+    sb.append(this.getBeginPosition());
+    sb.append("-");
+    sb.append(this.last_pre_types);
+    sb.append(",");
+    sb.append(this.first_post_type);
+    sb.append("-");
+    sb.append(this.last_pre_fields);
+    sb.append(",");
+    sb.append(this.first_post_fields);
+    sb.append("-");
+    sb.append(this.getEndPosition());
+    sb.append("}\n");
+    sb.append("Types:\n");
+    Iterator<DefEntryType> types_iter = this.types.iterator();
+    while (types_iter.hasNext()) {
+      DefEntryType typ = types_iter.next();
+      sb.append("   ");
+      sb.append(typ.toString());
+      sb.append("\n");
+    }
+    sb.append("Fields:\n");
+    Iterator<DefEntryField> flds_iter = this.fields.iterator();
+    while (flds_iter.hasNext()) {
+      DefEntryField fld = flds_iter.next();
+      sb.append("   ");
+      sb.append(fld.toString());
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryType.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryType.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.HashMap;
+import org.hpccsystems.spark.TargetColumn;
+
+/**
+ * A type definition object
+ */
+public class DefEntryType extends DefEntry implements Serializable {
+  static final long serialVersionUID = 1L;
+  private int used;
+  private String name;
+  private String childType;
+  private ArrayList<DefEntryField> fields;
+  private HashMap<String,DefEntryField> fldDict;
+  private int start_field_list;
+  private int stop_field_list;
+  /**
+   * Empty constructor for serialization supprt
+   */
+  protected DefEntryType() {
+  }
+  /**
+   * A DefEntryType for the objects described by the token sequence
+   * @param toks the array of tokens from the JSON definition
+   * @param startPos the ordinal of the start token
+   * @param tokCount the number of tokens
+   * @param parent the ordinal of the parent
+   */
+  public DefEntryType(DefToken[] toks, int startPos, int tokCount, int parent)
+      throws UnusableDataDefinitionException {
+    super(toks[startPos].getName(), startPos, startPos+tokCount-1, parent);
+    this.used = 0;
+    this.name = toks[startPos].getName();
+    this.childType = "";
+    for (int i=startPos+1; i<startPos+tokCount-1; i++) {
+      if (DefEntry.CHILD.equals(toks[i].getName())) {
+        this.childType = toks[i].getString();
+      }
+    }
+    this.fields = new ArrayList<DefEntryField>();
+    this.fldDict = new HashMap<String,DefEntryField>();
+    if (DefEntry.hasFields(toks, startPos, tokCount)) {
+      int curr_pos = startPos+1;
+      while (!DefEntry.FIELDS.equals(toks[curr_pos].getName())) {
+        curr_pos++;
+      }
+      if (!toks[curr_pos].isArrayStart()) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(DefEntry.FIELDS);
+        sb.append(" token was not an array.  Found ");
+        sb.append(toks[curr_pos].toString());
+        throw new UnusableDataDefinitionException(sb.toString());
+      }
+      this.start_field_list = curr_pos;
+      curr_pos++;
+      while(!toks[curr_pos].isArrayEnd()) {
+        int num_toks = DefEntry.getTokenCount(toks, curr_pos);
+        DefEntryField fld = new DefEntryField(toks, curr_pos, num_toks, startPos);
+        this.fields.add(fld);
+        this.fldDict.put(fld.getFieldName(), fld);
+        curr_pos += num_toks;
+      }
+      this.stop_field_list = curr_pos;
+    } else {
+      this.start_field_list = this.getEndPosition() - 1;
+      this.stop_field_list = this.getEndPosition();
+    }
+  }
+  /**
+   * Count the use of this type and fields defined by this type and named
+   * (perhaps implicitly) by the TargetColumn filter
+   * @param tc Columns targeted.  If this type has columns and the TargetColumn
+   * has no entries, then all columns are selected.
+   * @param typDict the type dictionary so referenced types can be updated
+   */
+  public void countUse(TargetColumn tc, HashMap<String,DefEntryType> typDict)
+      throws UnusableDataDefinitionException {
+    this.used++;
+    if (this.childType!="") {
+      if (!typDict.containsKey(this.childType)) {
+        throw new UnusableDataDefinitionException("Missing type " + this.childType);
+      }
+      DefEntryType chld = typDict.get(this.childType);
+      chld.countUse(tc, typDict);
+    }
+    if (this.fields.size()==0) return;
+    int marked = 0;
+    for (TargetColumn col : tc.getColumns()) {
+      if (this.fldDict.containsKey(col.getName())) {
+        marked++;
+        this.fldDict.get(col.getName()).countUse(col, typDict);
+      }
+    }
+    if (tc.allFields() || marked==0) {
+      for (DefEntryField fld : this.fields) {
+        fld.countUse(typDict);
+      }
+    }
+  }
+  public void countUse(HashMap<String,DefEntryType> typDict)
+      throws UnusableDataDefinitionException {
+    this.used++;
+    if (this.childType!="") {
+      if (!typDict.containsKey(this.childType)) {
+        throw new UnusableDataDefinitionException("Missing type " + this.childType);
+      }
+      DefEntryType chld = typDict.get(this.childType);
+      chld.countUse(typDict);
+    }
+    if (this.fields.size()==0) return;
+    for (DefEntryField fld : this.fields) {
+      fld.countUse(typDict);
+    }
+  }
+  /* (non-Javadoc)
+   * @see org.hpccsystems.spark.thor.DefEntry#toTokens(java.util.ArrayList)
+   */
+  @Override
+  public void toTokens(ArrayList<DefToken> toksNew, DefToken[] toksInput) {
+    if (this.used==0) return;
+    for (int i=this.getBeginPosition(); i<=this.start_field_list; i++) {
+      toksNew.add(toksInput[i]);
+    }
+    for (DefEntryField fld : this.fields) {
+      fld.toTokens(toksNew, toksInput);
+    }
+    for (int i=this.stop_field_list; i<=this.getEndPosition(); i++) {
+      toksNew.add(toksInput[i]);
+    }
+  }
+  @Override
+  public String toString() {
+    int initialSize = 40*(this.getEndPosition()-this.getBeginPosition()+1);
+    StringBuilder sb = new StringBuilder(initialSize);
+    sb.append("type ");
+    sb.append(this.name);
+    if (!this.childType.equals("")) {
+      sb.append("(");
+      sb.append(this.childType);
+      sb.append(")");
+    }
+    sb.append("{");
+    sb.append(this.getBeginPosition());
+    sb.append("-");
+    sb.append(this.getEndPosition());
+    sb.append(";");
+    sb.append(this.getTokenCount());
+    sb.append("} ");
+    if (this.fields.size() > 0) {
+      sb.append(" [");
+      Iterator<DefEntryField> flds = this.fields.iterator();
+      while (flds.hasNext()) {
+        DefEntryField fld = flds.next();
+        sb.append(fld.toString());
+        sb.append(";");
+      }
+      sb.append("]");
+    }
+    sb.append((this.used>0) ? " used"  : " unused");
+    return sb.toString();
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefToken.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefToken.java
@@ -34,8 +34,22 @@ public class DefToken {
   private final boolean whenBoolean;
   private final Integer parent;
   private final String name;
+  private final int level;
+  private final int position;
+  // public constructor for making a revised copy
+  public DefToken(DefToken base, Integer newParent, int newLvl, int newPos) {
+    this.tok = base.tok;
+    this.parent = newParent;
+    this.name = base.name;
+    this.whenString = base.whenString;
+    this.whenReal = base.whenReal;
+    this.whenInteger = base.whenInteger;
+    this.whenBoolean = base.whenBoolean;
+    this.level = newLvl;
+    this.position = newPos;
+  }
   // private constructors
-  private DefToken(JsonToken tok, Integer parent, String name) {
+  private DefToken(JsonToken tok, Integer parent, String name, int lvl, int pos) {
     this.tok = tok;
     this.parent = parent;
     this.name = name;
@@ -43,8 +57,11 @@ public class DefToken {
     this.whenReal = 0;
     this.whenInteger = 0;
     this.whenBoolean = false;
+    this.level = lvl;
+    this.position = pos;
   }
-  private DefToken(JsonToken tok, Integer parent, String name, String s) {
+  private DefToken(JsonToken tok, Integer parent, String name, String s, int lvl,
+                   int pos) {
     this.tok = tok;
     this.parent = parent;
     this.name = name;
@@ -52,8 +69,11 @@ public class DefToken {
     this.whenReal = 0;
     this.whenInteger = 0;
     this.whenBoolean = false;
+    this.level = lvl;
+    this.position = pos;
   }
-  private DefToken(JsonToken tok, Integer parent, String name, double d) {
+  private DefToken(JsonToken tok, Integer parent, String name, double d, int lvl,
+                    int pos) {
     this.tok = tok;
     this.parent = parent;
     this.name = name;
@@ -61,8 +81,11 @@ public class DefToken {
     this.whenReal = d;
     this.whenInteger = 0;
     this.whenBoolean = false;
+    this.level = lvl;
+    this.position = pos;
   }
-  private DefToken(JsonToken tok, Integer parent, String name, long l) {
+  private DefToken(JsonToken tok, Integer parent, String name, long l, int lvl,
+                   int pos) {
     this.tok = tok;
     this.parent = parent;
     this.name = name;
@@ -70,8 +93,11 @@ public class DefToken {
     this.whenReal = 0;
     this.whenInteger = l;
     this.whenBoolean = false;
+    this.level = lvl;
+    this.position = pos;
   }
-  private DefToken(JsonToken tok, Integer parent, String name, boolean b) {
+  private DefToken(JsonToken tok, Integer parent, String name, boolean b, int lvl,
+                  int pos) {
     this.tok = tok;
     this.parent = parent;
     this.name = name;
@@ -79,12 +105,29 @@ public class DefToken {
     this.whenReal = 0;
     this.whenInteger = 0;
     this.whenBoolean = b;
+    this.level = lvl;
+    this.position = pos;
   }
   // access methods
   /**
    * @return the JsonToken enumeration value
    */
   public JsonToken getToken() { return tok; }
+  /**
+   * Is this the object start:
+   * @return this is an OBJECT_START token
+   */
+  public boolean isObjectStart() { return this.tok==JsonToken.START_OBJECT; }
+  /**
+   * Is this the end of an array
+   * @return this is an END_ARRAY token
+   */
+  public boolean isArrayEnd() { return this.tok==JsonToken.END_ARRAY; }
+  /**
+   * Is this an array start?
+   * @return this is an START_ARRAY token
+   */
+  public boolean isArrayStart() { return this.tok==JsonToken.START_ARRAY; }
   /**
    * @return the position in the array of the parent
    */
@@ -98,6 +141,62 @@ public class DefToken {
    */
   public String getString() { return whenString; }
   /**
+   * The value in hex when the object is a string.
+   * @return a hex string
+   */
+  public String getHexString() {
+    return getHexString(this.whenString);
+  }
+  /**
+   * The string value as hex.
+   * @param s the string
+   * @return the hex representation
+   */
+  public static String getHexString(String s) {
+    StringBuilder sb = new StringBuilder();
+    for (int i=0; i<s.length(); i++) {
+      sb.append(String.format("%04X ", s.codePointAt(i)));
+    }
+    return sb.toString();
+  }
+  /**
+   * Does the value have any control caharacters?
+   * @return
+   */
+  public boolean hasControlChar() {
+    return hasControlChar(whenString);
+  }
+  /**
+   * Dord the string s have any control characters?
+   * @param s the string to check
+   * @return true if control characters are found, false otherwise
+   */
+  static public boolean hasControlChar(String s) {
+    for (int i=0; i<s.length(); i++) {
+      if (Character.isISOControl(s.charAt(i))) return true;
+    }
+    return false;
+  }
+  /**
+   * Copy the srting and replace control characters with escapes like
+   * a "\u0001" string for a 0x00001 control character.
+   * @param str the string to copy and escape
+   * @return the escaped string
+   */
+  static public String escapeControls(String str) {
+    StringBuilder sb = new StringBuilder();
+    for (int i=0; i<str.length(); i++) {
+      char c = str.charAt(i);
+      if (Character.isISOControl(c)) {
+        sb.append("\\u");
+        sb.append(String.format("%04X", str.codePointAt(i)));
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+  /**
    * @return the floating point value if the type was REAL
    */
   public double getReal() { return whenReal; }
@@ -109,9 +208,31 @@ public class DefToken {
    * @return the boolean value if the token was a true or false
    */
   public boolean getBoolean() { return whenBoolean; }
-
+  /**
+   * @return the ordinal position of this token in the stream
+   */
+  public int getPosition() { return position; }
+  /**
+   * @return the depth level of this token in the tree
+   */
+  public int getLevel() { return level; }
+  /**
+   * Is this the first element of the object or array?
+   * @return true when this is the first element of the object or array
+   */
+  public boolean isFirstElement() {
+    return this.position == 0
+        || this.position == this.parent+1;
+  }
+  /**
+   * @return the token in human readable form.
+   */
   public String toString() {
     StringBuilder sb = new StringBuilder();
+    sb.append(position);
+    sb.append(": ");
+    sb.append(level);
+    sb.append(" ");
     sb.append(parent);
     sb.append(" ");
     sb.append(name);
@@ -129,6 +250,11 @@ public class DefToken {
       case VALUE_STRING:
         sb.append(":");
         sb.append(whenString);
+        if (this.hasControlChar()) {
+          sb.append(" {");
+          sb.append(this.getHexString());
+          sb.append("}");
+        }
         break;
       case VALUE_TRUE:
       case VALUE_FALSE:
@@ -140,6 +266,63 @@ public class DefToken {
     }
     return sb.toString();
   }
+  public String toJson() {
+    StringBuilder sb = new StringBuilder();
+    if (this.tok==JsonToken.END_OBJECT) {
+      sb.append("\n");
+      for (int i=0; i<this.level; i++) sb.append("  ");
+      sb.append("}");
+    } else if (this.tok==JsonToken.END_ARRAY) {
+      sb.append("\n");
+      for (int i=0; i<this.level; i++) sb.append("  ");
+      sb.append("]");
+    } else if (this.tok==JsonToken.START_OBJECT) {
+      sb.append( (this.isFirstElement())  ? "\n"  : ",\n");
+      for (int i=0; i<this.level; i++) sb.append("  ");
+      if (this.name!=null) {
+        sb.append("\"");
+        sb.append(this.name);
+        sb.append("\"  : {");
+      } else {
+        sb.append("{");
+      }
+    } else if (this.tok==JsonToken.START_ARRAY) {
+      sb.append( (this.isFirstElement())  ? "\n"  : ",\n");
+      for (int i=0; i<this.level; i++) sb.append("  ");
+      sb.append("\"");
+      sb.append(this.name);
+      sb.append("\" : [");
+    } else {
+      sb.append( (this.isFirstElement())  ? "\n"  : ",\n");
+      for (int i=0; i<this.level; i++) sb.append("  ");
+      sb.append("\"");
+      sb.append(this.name);
+      sb.append("\"  : \"");
+      switch(tok) {
+        case VALUE_NUMBER_INT:
+          sb.append(Long.toString(this.whenInteger));
+          break;
+        case VALUE_NUMBER_FLOAT:
+          sb.append(Double.toString(this.whenReal));
+          break;
+        case VALUE_STRING:
+          sb.append(this.whenString);
+          break;
+        case VALUE_TRUE:
+        case VALUE_FALSE:
+          sb.append(Boolean.toString(this.whenBoolean));
+          break;
+        default:
+          break;
+      }
+      sb.append("\"");
+    }
+    return sb.toString();
+  }
+  public static boolean pairedTypes(JsonToken open, JsonToken close) {
+    return (open==JsonToken.START_OBJECT && close==JsonToken.END_OBJECT)
+        || (open==JsonToken.START_ARRAY  && close==JsonToken.END_ARRAY);
+  }
   /**
    * Parse the JSON encoded definition string into an array of
    * tokens.  The def string should never cause an IOException,
@@ -150,7 +333,7 @@ public class DefToken {
    * @return an array of tokens
    * @throws JsonParseException
    */
-  public static ArrayList<DefToken> parseDefString(String def)
+  public static DefToken[] parseDefString(String def)
             throws JsonParseException {
     ArrayList<DefToken> tokens = new ArrayList<DefToken>();
     Integer parent = new Integer(-1);
@@ -174,22 +357,27 @@ public class DefToken {
           parent = parent_stack.pop();
         }
         String name = jp.getCurrentName();
+        int lvl = parent_stack.size();
+        int pos = tokens.size();
         switch (tok) {
           case VALUE_NUMBER_INT:
-            curr = new DefToken(tok, parent, name, jp.getLongValue());
+            curr = new DefToken(tok, parent, name, jp.getLongValue(), lvl, pos);
             break;
           case VALUE_NUMBER_FLOAT:
-            curr = new DefToken(tok, parent, name, jp.getDoubleValue());
+            curr = new DefToken(tok, parent, name, jp.getDoubleValue(), lvl, pos);
             break;
           case VALUE_TRUE:
           case VALUE_FALSE:
-            curr = new DefToken(tok, parent, name, jp.getBooleanValue());
+            curr = new DefToken(tok, parent, name, jp.getBooleanValue(), lvl, pos);
             break;
           case VALUE_STRING:
-            curr = new DefToken(tok, parent, name, jp.getText());
+            String str = (DefToken.hasControlChar(jp.getText()))
+                      ? DefToken.escapeControls(jp.getText())
+                      : jp.getText();
+            curr = new DefToken(tok, parent, name, str, lvl, pos);
             break;
           default:
-            curr = new DefToken(tok, parent, name);
+            curr = new DefToken(tok, parent, name, lvl, pos);
         }
         tokens.add(curr);
         if (tok==JsonToken.START_OBJECT || tok==JsonToken.START_ARRAY) {
@@ -202,6 +390,25 @@ public class DefToken {
       String msg = "JSON Parse triggered IO exception";
       throw new IllegalArgumentException(msg, e);
     }
-    return tokens;
+    return tokens.toArray(new DefToken[0]);
+  }
+  /**
+   * Renumber the token array after pruning.
+   * @param toks the token array to be updated in place
+   */
+  public static void renumber(DefToken[] toks) {
+    Integer parent = new Integer(-1);
+    Deque<Integer> parent_stack = new ArrayDeque<Integer>();
+    for (int i=0; i<toks.length; i++) {
+      if (toks[i].tok==JsonToken.END_OBJECT || toks[i].tok==JsonToken.END_ARRAY) {
+        parent = parent_stack.pop();
+      }
+      int lvl = parent_stack.size();
+      toks[i] = new DefToken(toks[i], parent.intValue(), lvl, i);
+      if (toks[i].tok==JsonToken.START_OBJECT || toks[i].tok==JsonToken.START_ARRAY) {
+        parent_stack.push(parent);
+        parent = new Integer(i);
+      }
+    }
   }
 }

--- a/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
@@ -59,6 +59,9 @@ public class DataframeTest {
     System.out.print("pass word: ");
     System.out.flush();
     String pword = br.readLine();
+    System.out.print("Field list or empty: ");
+    System.out.flush();
+    String fieldList = br.readLine();
     System.out.print("Number of nodes for remap or empty: ");
     System.out.flush();
     String nodes = br.readLine();
@@ -67,10 +70,11 @@ public class DataframeTest {
     String base_ip = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,
+          fieldList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();

--- a/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
@@ -33,6 +33,9 @@ public class HpccFileTest {
     System.out.print("pass word: ");
     System.out.flush();
     String pword = br.readLine();
+    System.out.print("Field list or empty: ");
+    System.out.flush();
+    String fieldList = br.readLine();
     System.out.print("Number of nodes for remap or empty: ");
     System.out.flush();
     String nodes = br.readLine();
@@ -41,10 +44,11 @@ public class HpccFileTest {
     String base_ip = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,
+          fieldList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();

--- a/DataAccess/src/test/java/org/hpccsystems/spark/PruneTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/PruneTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+
+import org.hpccsystems.spark.thor.DefEntryRoot;
+import org.hpccsystems.spark.thor.DefToken;
+import org.hpccsystems.spark.thor.DefEntry;
+import org.hpccsystems.spark.thor.DefEntryRoot;
+import org.hpccsystems.spark.thor.FieldDef;
+import org.hpccsystems.spark.thor.RemapInfo;
+import org.hpccsystems.ws.client.HPCCWsDFUClient;
+import org.hpccsystems.ws.client.platform.DFUFileDetailInfo;
+import org.hpccsystems.ws.client.utils.Connection;
+
+public class PruneTest {
+
+  public static void main(String[] args) throws Exception{
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    System.out.print("Enter protocol: ");
+    System.out.flush();
+    String protocol = br.readLine();
+    System.out.print("Enter ip: ");
+    System.out.flush();
+    String esp_ip = br.readLine();
+    System.out.print("Enter port: ");
+    System.out.flush();
+    String port = br.readLine();
+    System.out.print("Enter file name: ");
+    System.out.flush();
+    String fileName = br.readLine();
+    System.out.print("User id: ");
+    System.out.flush();
+    String user = br.readLine();
+    System.out.print("pass word: ");
+    System.out.flush();
+    String pword = br.readLine();
+    System.out.print("Field list or empty: ");
+    System.out.flush();
+    String fieldList = br.readLine();
+    // pick up DFU info
+    Connection conn = new Connection(protocol, esp_ip, port);
+    conn.setUserName(user);
+    conn.setPassword(pword);
+    HPCCWsDFUClient hpcc = HPCCWsDFUClient.get(conn);
+    System.out.println("Getting Json record definition");
+    DFUFileDetailInfo fd = hpcc.getFileDetails(fileName, "", true, false);
+    String defThor = fd.getJsonInfo();
+    System.out.println(defThor);
+    DefToken[] toks = DefToken.parseDefString(defThor);
+    System.out.println("JSON string from tokens:");
+    StringBuffer orig_sb = new StringBuffer();
+    for (DefToken tok : toks) {
+      orig_sb.append(tok.toJson());
+    }
+    System.out.println(orig_sb.toString());
+    System.out.println("Tokens");
+    for (int i=0; i<toks.length; i++) {
+      System.out.println(toks[i].toString());
+    }
+    System.out.println("Pruned tokens:");
+    ColumnPruner cp = new ColumnPruner(fieldList);
+    TargetColumn tcRoot = cp.getTargetColumn();
+    DefEntryRoot root = new DefEntryRoot(toks);
+    root.countUse(tcRoot);
+    System.out.println(root.toString());
+    ArrayList<DefToken> work_list = new ArrayList<DefToken>();
+    root.toTokens(work_list, toks);
+    DefToken[] pruned_toks = work_list.toArray(new DefToken[0]);
+    DefToken.renumber(pruned_toks);
+    for (DefToken tok : pruned_toks) System.out.println(tok.toString());
+    System.out.println("Output JSON string");
+    StringBuilder def_sb = new StringBuilder();
+    for (DefToken tok : pruned_toks) {
+      def_sb.append(tok.toJson());
+    }
+    System.out.println(def_sb.toString());
+    System.out.println("Done");
+  }
+  // end test
+}

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
@@ -30,6 +30,9 @@ public class RecordTest {
     System.out.print("pass word: ");
     System.out.flush();
     String pword = br.readLine();
+    System.out.print("Field list or empty: ");
+    System.out.flush();
+    String fieldList = br.readLine();
     System.out.print("Number of nodes for remap or empty: ");
     System.out.flush();
     String nodes = br.readLine();
@@ -38,10 +41,11 @@ public class RecordTest {
     String base_ip = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, ri);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,
+          fieldList, ri);
     }
     System.out.println("Getting file parts");
     FilePart[] parts = hpcc.getFileParts();


### PR DESCRIPTION
Changed HpccFile to accept a field list string as a selection parameter.  List is comma separated with compound names in normal dot notation.  Changed RecordDef to have the original JSON data definition changed.  Changed the DefToken to convert back to string format.

Added ColumnPruner, TargetColumn, and DefEntry et.al. to implement pruning fields and types from the output definition.

Updated test programs to solicit a field selection string.  Simplified RDDTest to only show data on console.

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>