### PR TITLE
HPCC-19375 Index pull into Spark environment

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccDataframeFactory.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccDataframeFactory.java
@@ -39,7 +39,7 @@ public class HpccDataframeFactory implements Serializable{
   }
   Dataset<Row> getDataframe(HpccFile hpcc) throws HpccFileException {
     RecordDef rd = hpcc.getRecordDefinition();
-    FilePart[] fp = hpcc.getFileParts();
+    HpccPart[] fp = hpcc.getFileParts();
     JavaRDD<Record> jRDD = (new HpccRDD(ss.sparkContext(), fp, rd)).asJavaRDD();
     Function<Record, Row> map_f = new Function<Record, Row>() {
       static private final long serialVersionUID = 1L;

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccPart.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccPart.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+/**
+ *
+ */
+package org.hpccsystems.spark;
+
+import java.io.Serializable;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Comparator;
+
+import org.apache.spark.Partition;
+import org.hpccsystems.spark.thor.DataPartition;
+import org.hpccsystems.spark.thor.FileFilter;
+import org.hpccsystems.spark.thor.RemapInfo;
+import org.hpccsystems.ws.client.platform.DFUFileDetailInfo;
+import org.hpccsystems.ws.client.platform.DFUFilePartInfo;
+
+/**
+ * A file part of an HPCC file.  This is the Spark partition for the RDD.
+ *
+ */
+public class HpccPart implements Partition, Serializable {
+  static private final long serialVersionUID = 1L;
+  private DataPartition dataPart;
+  private int this_part;
+  private int num_parts;
+
+  /**
+   * Construct the file part, used by makeParts
+   * @param parts the number of partitions
+   * @param part_ordinal the ordinal position of this part
+   * @param part the data partition
+   */
+  private HpccPart(int parts, int part_ordinal, DataPartition part) {
+    this.dataPart = part;
+    this.this_part = part_ordinal;
+    this.num_parts = parts;
+  }
+
+  /**
+   * Partition information
+   * @return information
+   */
+  public DataPartition getPartitionInfo() { return this.dataPart; }
+  /* (non-Javadoc)
+   * @see org.apache.spark.Partition#index()
+   */
+  public int index() {
+    return this.this_part - 1;
+  }
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object
+   */
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(this.this_part);
+    sb.append(" ");
+    sb.append(this.dataPart.toString());
+    return sb.toString();
+  }
+  /* (non-Javadoc)
+   * Spark core 2.10 needs this defined, not needed in 2.11
+   */
+  public boolean org$apache$spark$Partition$$super$equals(Object arg0) {
+    if (!(arg0 instanceof HpccPart)) return false;
+    HpccPart fp0 = (HpccPart) arg0;
+    DataPartition dp0 = fp0.getPartitionInfo();
+    if (!this.dataPart.equals(dp0)) return false;
+    if (this.this_part != fp0.this_part) return false;
+    if (this.num_parts != fp0.num_parts) return false;
+    return true;
+  }
+  /**
+   * Create an array of Spark partition objects for HPCC file parts.
+   * @param fdi File detail information for the file
+   * @param max_parts the maximum number of partitions or zero for no max
+   * @param filter a filter expression to select records which may be
+   * set to FileFilter.nullFilter() for all records.
+   * @return an array of partitions for Spark
+   */
+  public static HpccPart[] makeFileParts(DFUFileDetailInfo fdi,
+      RemapInfo remap_info, int max_parts, FileFilter filter)
+          throws HpccFileException {
+    DataPartition[] dataParts
+              = DataPartition.createPartitions(fdi, remap_info, max_parts, filter);
+    HpccPart[] rslt = new HpccPart[dataParts.length];
+    for (int i=0; i<rslt.length; i++ ) {
+      rslt[i] = new HpccPart(dataParts.length, i+1, dataParts[i]);
+    }
+    return rslt;
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccRDD.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccRDD.java
@@ -47,15 +47,15 @@ public class HpccRDD extends RDD<Record> implements Serializable {
   private static Seq<Dependency<RDD<Record>>> empty
           = new ArraySeq<Dependency<RDD<Record>>>(0);
   //
-  private FilePart[] parts;
+  private HpccPart[] parts;
   private RecordDef def;
   /**
    * @param _sc
    * @param
    */
-  public HpccRDD(SparkContext _sc, FilePart[] parts, RecordDef def) {
+  public HpccRDD(SparkContext _sc, HpccPart[] parts, RecordDef def) {
     super(_sc, (Seq)empty, CT_RECORD);
-    this.parts = new FilePart[parts.length];
+    this.parts = new HpccPart[parts.length];
     for (int i=0; i<parts.length; i++) {
       this.parts[i] = parts[i];
     }
@@ -106,7 +106,7 @@ public class HpccRDD extends RDD<Record> implements Serializable {
    */
   @Override
   public InterruptibleIterator<Record> compute(Partition p_arg, TaskContext ctx) {
-    final FilePart this_part = (FilePart) p_arg;
+    final HpccPart this_part = (HpccPart) p_arg;
     final RecordDef rd = this.def;
     Iterator<Record> iter = new Iterator<Record>() {
       private HpccRemoteFileReader rfr = new HpccRemoteFileReader(this_part, rd);
@@ -126,7 +126,7 @@ public class HpccRDD extends RDD<Record> implements Serializable {
    */
   @Override
   public Partition[] getPartitions() {
-    FilePart[] rslt = new FilePart[this.parts.length];
+    HpccPart[] rslt = new HpccPart[this.parts.length];
     for (int i=0; i<this.parts.length; i++) rslt[i] = this.parts[i];
     return rslt;
   }

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccRemoteFileReader.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccRemoteFileReader.java
@@ -23,18 +23,18 @@ import org.hpccsystems.spark.thor.BinaryRecordReader;
  */
 public class HpccRemoteFileReader {
   private RecordDef def;
-  private FilePart fp;
+  private HpccPart fp;
   private BinaryRecordReader brr;
   /**
    * A remote file reader that reads the part identified by the
-   * FilePart object using the record definition provided.
+   * HpccPart object using the record definition provided.
    * @param def the definition of the data
    * @param fp the part of the file, name and location
    */
-  public HpccRemoteFileReader(FilePart fp, RecordDef rd) {
+  public HpccRemoteFileReader(HpccPart fp, RecordDef rd) {
     this.def = rd;
     this.fp = fp;
-    this.brr = new BinaryRecordReader(fp, def);
+    this.brr = new BinaryRecordReader(fp.getPartitionInfo(), def);
   }
   /**
    * Is there more data

--- a/DataAccess/src/main/java/org/hpccsystems/spark/package-info.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/package-info.java
@@ -24,7 +24,7 @@
  * <li>Content is the abstract class defining field content.  There are concrete
  * classes for each of the different content types. </li>
  * <li>FieldType is an enumeration type listing the types of content.</li>
- * <li>FilePart implements the Spark Partition interface.</li>
+ * <li>HpccPart implements the Spark Partition interface.</li>
  * <li>HpccFile is the metadata for a file on an HPCC THOR cluster.</li>
  * <li>HpccFileException is the general exception class.</li>
  * <li>HpccRDD extends RDD<Record> class for Spark.</li>

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/BinaryRecordReader.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/BinaryRecordReader.java
@@ -26,7 +26,6 @@ import org.hpccsystems.spark.BinarySeqContent;
 import org.hpccsystems.spark.BooleanContent;
 import org.hpccsystems.spark.BooleanSeqContent;
 import org.hpccsystems.spark.Content;
-import org.hpccsystems.spark.FilePart;
 import org.hpccsystems.spark.HpccFileException;
 import org.hpccsystems.spark.IntegerContent;
 import org.hpccsystems.spark.IntegerSeqContent;
@@ -62,14 +61,14 @@ public class BinaryRecordReader implements IRecordReader {
    * @param fp the file part to be read
    * @param rd the record def
    */
-  public BinaryRecordReader(FilePart fp, RecordDef rd) {
+  public BinaryRecordReader(DataPartition dp, RecordDef rd) {
     this.recDef = rd;
-    this.pc = new PlainConnection(fp, rd);
+    this.pc = new PlainConnection(dp, rd);
     this.curr = new byte[0];
     this.curr_pos = 0;
     this.active = false;
     this.pos = 0;
-    this.part = fp.getThisPart();
+    this.part = dp.getThisPart();
     this.defaultLE = true;
   }
 

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/ClusterRemapper.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/ClusterRemapper.java
@@ -66,15 +66,14 @@ public abstract class ClusterRemapper {
    * Factory for making a cluster re-map.
    * @param ri the re-mapping information
    * @param fpiList a list of the file parts
-   * @param parts the number of file parts
    * @return a re-mapping object consistent with the provided information
    * @throws HpccFileException
    */
   public static ClusterRemapper makeMapper(RemapInfo ri,
-      DFUFilePartInfo[] fpiList, int parts) throws HpccFileException {
+      DFUFilePartInfo[] fpiList) throws HpccFileException {
     ClusterRemapper rslt = (ri.isNullMapper()) ? new NullRemapper(ri)
         : (ri.isPortAliasing()) ? new PortRemapper(ri)
-            : new AddrRemapper(ri, fpiList, parts);
+            : new AddrRemapper(ri, fpiList);
     return rslt;
   }
 }

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntry.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntry.java
@@ -25,23 +25,17 @@ import org.hpccsystems.spark.thor.UnusableDataDefinitionException;
  */
 public abstract class DefEntry implements Serializable {
   static final long serialVersionUID = 1L;
-  public static final String FIELDS = "fields";
-  public static final String CHILD = "child";
-  public static final String NAME = "name";
-  public static final String TYPE = "type";
+  public static final String FIELDS = "fields";     // root and type objects
+  public static final String CHILD = "child";       // type objects
+  public static final String NAME = "name";         // field entry
+  public static final String TYPE = "type";         // field entry
+  public static final String LENGTH = "length";     // type object
+  public static final String FIELDTYPE = "fieldType";//type object
+  public static final String FLAGS = "flags";       // field entry
   private String name;
   private int beginPosition;
   private int endPosition;
   private int parentPosition;
-  /**
-   * Empty constructor for serialization support.
-   */
-  protected DefEntry() {
-    this.name = "";
-    this.beginPosition = -1;
-    this.endPosition = -1;
-    this.parentPosition = -1;
-  }
   /**
    * Normal constructor.  Positions are provided by setter methods.
    * @param n the name of the object or the empty string if unnamed.
@@ -66,6 +60,17 @@ public abstract class DefEntry implements Serializable {
    * @return the readable information.
    */
   public abstract String toString();
+  /**
+   * Is this entry suppressed?  Some data types found on the HPCCSystems
+   * platform are not supported.  For example, an Alien Datatype is not
+   * supported because the data access definitions are not transportable code.
+   * @return true if this entry is suppressed.
+   */
+  public abstract boolean isSuppressed();
+  /**
+   * Mark the entry as suppressed.
+   */
+  public abstract void suppressEntry();
  /**
    * the object name or the empty string if unnamed
    * @return the name
@@ -101,7 +106,6 @@ public abstract class DefEntry implements Serializable {
    */
   public static DefToken[] pruneDefTokens(DefToken[] toks, TargetColumn tc)
       throws UnusableDataDefinitionException {
-    if (tc.allFields()) return toks;
     DefEntryRoot root = new DefEntryRoot(toks);
     root.countUse(tc);
     ArrayList<DefToken> work_list = new ArrayList<DefToken>();

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryType.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefEntryType.java
@@ -29,33 +29,55 @@ public class DefEntryType extends DefEntry implements Serializable {
   private int used;
   private String name;
   private String childType;
+  private long length;
+  private long fieldType;
+  private boolean suppressType;
+  private boolean updatedType;
   private ArrayList<DefEntryField> fields;
   private HashMap<String,DefEntryField> fldDict;
   private int start_field_list;
   private int stop_field_list;
-  /**
-   * Empty constructor for serialization supprt
-   */
-  protected DefEntryType() {
-  }
   /**
    * A DefEntryType for the objects described by the token sequence
    * @param toks the array of tokens from the JSON definition
    * @param startPos the ordinal of the start token
    * @param tokCount the number of tokens
    * @param parent the ordinal of the parent
+   * @param typeDict the type dictionary, used to lookup a referenced
+   * type if present to determine if this type references a suppressed
+   * type
    */
-  public DefEntryType(DefToken[] toks, int startPos, int tokCount, int parent)
+  public DefEntryType(DefToken[] toks, int startPos, int tokCount, int parent,
+      HashMap<String,DefEntryType> typeDict)
       throws UnusableDataDefinitionException {
     super(toks[startPos].getName(), startPos, startPos+tokCount-1, parent);
     this.used = 0;
     this.name = toks[startPos].getName();
     this.childType = "";
+    this.fieldType = 0;
+    this.length = 0;
     for (int i=startPos+1; i<startPos+tokCount-1; i++) {
       if (DefEntry.CHILD.equals(toks[i].getName())) {
         this.childType = toks[i].getString();
+      } else if (DefEntry.FIELDTYPE.equals(toks[i].getName())) {
+        this.fieldType = toks[i].getInteger();
+      } else if (DefEntry.LENGTH.equals(toks[i].getName())) {
+        this.length = toks[i].getInteger();
       }
     }
+    this.suppressType = TypeDef.suppressType(this.fieldType);
+    if (!this.childType.equals("")) {
+      if (!typeDict.containsKey(this.childType)) {
+        String msg = "Unknown child reference of " + this.childType;
+        throw new UnusableDataDefinitionException(msg);
+      }
+      this.suppressType = this.suppressType
+                       || typeDict.get(this.childType).isSuppressed();
+    }
+    TypeDef.Revision rt = TypeDef.getRevision(this.fieldType, this.length);
+    this.updatedType = rt.revised;
+    this.fieldType = rt.revisedType;
+    this.length = rt.revisedLength;
     this.fields = new ArrayList<DefEntryField>();
     this.fldDict = new HashMap<String,DefEntryField>();
     if (DefEntry.hasFields(toks, startPos, tokCount)) {
@@ -74,9 +96,11 @@ public class DefEntryType extends DefEntry implements Serializable {
       curr_pos++;
       while(!toks[curr_pos].isArrayEnd()) {
         int num_toks = DefEntry.getTokenCount(toks, curr_pos);
-        DefEntryField fld = new DefEntryField(toks, curr_pos, num_toks, startPos);
+        DefEntryField fld = new DefEntryField(toks, curr_pos, num_toks,
+                                              startPos, typeDict);
         this.fields.add(fld);
         this.fldDict.put(fld.getFieldName(), fld);
+        if (this.suppressType) fld.suppressEntry();
         curr_pos += num_toks;
       }
       this.stop_field_list = curr_pos;
@@ -84,6 +108,7 @@ public class DefEntryType extends DefEntry implements Serializable {
       this.start_field_list = this.getEndPosition() - 1;
       this.stop_field_list = this.getEndPosition();
     }
+
   }
   /**
    * Count the use of this type and fields defined by this type and named
@@ -136,19 +161,20 @@ public class DefEntryType extends DefEntry implements Serializable {
    */
   @Override
   public void toTokens(ArrayList<DefToken> toksNew, DefToken[] toksInput) {
-    if (this.used==0) return;
+    if (this.used==0 || this.suppressType) return;
     for (int i=this.getBeginPosition(); i<=this.start_field_list; i++) {
-      toksNew.add(toksInput[i]);
+      toksNew.add(reviseToken(toksInput[i]));
     }
     for (DefEntryField fld : this.fields) {
       fld.toTokens(toksNew, toksInput);
     }
     for (int i=this.stop_field_list; i<=this.getEndPosition(); i++) {
-      toksNew.add(toksInput[i]);
+      toksNew.add(reviseToken(toksInput[i]));
     }
   }
   @Override
   public String toString() {
+    if (this.suppressType) return "type " + this.name + " supressed";
     int initialSize = 40*(this.getEndPosition()-this.getBeginPosition()+1);
     StringBuilder sb = new StringBuilder(initialSize);
     sb.append("type ");
@@ -177,5 +203,26 @@ public class DefEntryType extends DefEntry implements Serializable {
     }
     sb.append((this.used>0) ? " used"  : " unused");
     return sb.toString();
+  }
+  @Override
+  public boolean isSuppressed() {
+    return this.suppressType;
+  }
+  @Override
+  public void suppressEntry() {
+    this.suppressType = true;
+  }
+  /**
+   * A revised token if update values
+   * @param tok the token to be evaluated for change
+   * @return the original or a revised token
+   */
+  private DefToken reviseToken(DefToken tok) {
+    if (this.updatedType && FIELDTYPE.equals(tok.getName())) {
+      return new DefToken(tok, this.fieldType);
+    } else if (this.updatedType && LENGTH.equals(tok.getName())) {
+      return new DefToken(tok, this.length);
+    }
+    return tok;
   }
 }

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefToken.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/DefToken.java
@@ -36,7 +36,13 @@ public class DefToken {
   private final String name;
   private final int level;
   private final int position;
-  // public constructor for making a revised copy
+  /**
+   * Make a revised copy, revising parent, level, and position.
+   * @param base the original to be revised
+   * @param newParent the new parent ordinal
+   * @param newLvl the new level ordinal
+   * @param newPos the new position ordinal
+   */
   public DefToken(DefToken base, Integer newParent, int newLvl, int newPos) {
     this.tok = base.tok;
     this.parent = newParent;
@@ -47,6 +53,20 @@ public class DefToken {
     this.whenBoolean = base.whenBoolean;
     this.level = newLvl;
     this.position = newPos;
+  }
+  public DefToken(DefToken base, long newTypeOrLength) {
+    if (base.tok!=JsonToken.VALUE_NUMBER_INT) {
+      throw new IllegalArgumentException("Not an integer token");
+    }
+    this.tok = base.tok;
+    this.parent = base.parent;
+    this.name = base.name;
+    this.whenString = base.whenString;
+    this.whenReal = base.whenReal;
+    this.whenInteger = newTypeOrLength;
+    this.whenBoolean = base.whenBoolean;
+    this.level = base.level;
+    this.position = base.position;
   }
   // private constructors
   private DefToken(JsonToken tok, Integer parent, String name, int lvl, int pos) {

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldFilter.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldFilter.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.io.Serializable;
+
+/**
+ * A field filter.  Consists of a field name and a list of one or
+ * more alternative value ranges.
+ */
+public class FieldFilter implements Serializable {
+  public static final long serialVersionUID = 1L;
+  private String name;
+  private FieldFilterRange[] ranges;
+  private short prefix;
+  /**
+   * A field filter.
+   * @param fieldName
+   * @param filterRanges
+   */
+  public FieldFilter(String fieldName, FieldFilterRange[] filterRanges) {
+    this(fieldName, filterRanges, (short)0);
+  }
+  /**
+   * A field filter that checks only a prefix of of the field.
+   * @param fieldName the name of a field, can be a compound name.
+   * @param filterRanges the list of alternative values
+   * @param prefixMatchLength length for the test, zero means entire field
+   */
+  public FieldFilter(String fieldName, FieldFilterRange[] filterRanges,
+      short prefixMatchLength) {
+    this.name = fieldName;
+    this.ranges = new FieldFilterRange[filterRanges.length];
+    for (int i=0; i<this.ranges.length; i++) {
+      this.ranges[i] = filterRanges[i];
+    }
+    this.prefix = prefixMatchLength;
+  }
+  /**
+   * A wild card field filter.
+   * @param fieldName the field name
+   */
+  public FieldFilter(String fieldName) {
+    this.name = fieldName;
+    this.ranges = new FieldFilterRange[0];
+    this.prefix = 0;
+  }
+  /**
+   * A string suitable for inclusion into a JSON request
+   * @return the filter expression in string form
+   */
+  public String filterExpression() {
+    StringBuilder sb = new StringBuilder(20+this.name.length()+50*ranges.length);
+    sb.append(this.name);
+    if (this.ranges.length==0) {
+      sb.append("*");
+    } else if (this.prefix>0) {
+      sb.append(":");
+      sb.append(Short.toString(this.prefix));
+    }
+    if (this.ranges.length>0) {
+      sb.append("=");
+      sb.append(this.ranges[0].filterExpression());
+      for (int i=1; i<this.ranges.length; i++) {
+        sb.append(",");
+        sb.append(this.ranges[i].filterExpression());
+      }
+    }
+    return sb.toString();
+  }
+  /**
+   * the field name
+   */
+  public String getFieldName() { return this.name; }
+  /**
+   * The sumber of ranges used in this filter.
+   */
+  public int getRangeCount() { return this.ranges.length; }
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  public String toString() { return this.filterExpression(); }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldFilterRange.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/FieldFilterRange.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.io.Serializable;
+
+/**
+ * A filter value range.  Used to construct a range (open or closed on either end)
+ * of values for filtering records.  The value range can be a single value for
+ * an equality filter.
+ */
+public class FieldFilterRange implements Serializable {
+  /**
+   * The Lower, Upper, Both, Unbounded are the possibilities for
+   * bounding the range.
+   */
+  public enum Bound implements Serializable {
+    LOWER, UPPER, BOTH, NONE;
+  }
+  public static final long serialVersionUID = 1L;
+  private String[] values;
+  private boolean leftOpen;
+  private boolean rightOpen;
+  private boolean number;
+  private boolean set;
+  private Bound bound;
+  /**
+   * Use for single value ranges.
+   * @param v the value
+   * @param leftOpen true when the left is an open interval value
+   * @param rightOpen true when the right is an open interval value
+   * @param numeric_target the field under compare is numeric
+   */
+  public FieldFilterRange(String v, Bound rangeBound,
+      boolean leftRangeOpen, boolean rightRangeOpen, boolean numeric_target) {
+    this.values = new String[1];
+    this.values[0] = v;
+    this.bound = rangeBound;
+    this.leftOpen = leftRangeOpen;
+    this.rightOpen = rightRangeOpen;
+    this.number = numeric_target;
+    this.set = false;
+  }
+  /**
+   * Use for bounded range.
+   * @param low
+   * @param high
+   * @param leftRangeOpen
+   * @param rightRangeOpen
+   * @param numeric_target
+   */
+  public FieldFilterRange(String low, String high,
+      boolean leftRangeOpen, boolean rightRangeOpen, boolean numeric_target) {
+    this.bound = Bound.BOTH;
+    this.values = new String[2];
+    this.values[0] = low;
+    this.values[1] = high;
+    this.leftOpen = leftRangeOpen;
+    this.rightOpen = rightRangeOpen;
+    this.set = false;
+    this.number = numeric_target;
+  }
+  /**
+   * Use for a set of discrete values
+   * @param valueList
+   * @param numeric_target
+   */
+  public FieldFilterRange(String[] valueList, boolean numeric_target) {
+    this.leftOpen = false;
+    this.rightOpen = false;
+    this.number = numeric_target;
+    this.values = new String[valueList.length];
+    for (int i=0; i<this.values.length; i++) {
+      this.values[i] = valueList[i];
+    }
+    this.bound = Bound.BOTH;
+    this.set = true;
+    this.number = numeric_target;
+  }
+  /**
+   * Numeric equality.
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeEq(double v) {
+    return new FieldFilterRange(Double.toString(v), Bound.BOTH, false, false, true);
+  }
+  /**
+   * String value equality
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeEq(String v) {
+    return new FieldFilterRange(v, Bound.BOTH, false, false, false);
+  }
+  /**
+   * Numeric value inequality.
+   * @param v the test value
+   * @return the test ranges
+   */
+  static public FieldFilterRange makeNE(double v) {
+    return new FieldFilterRange(Double.toString(v), Bound.NONE, true, true, true);
+  }
+  /**
+   * String value inequality
+   * @param v the test value
+   * @return the test ranges
+   */
+  static public FieldFilterRange makeNE(String v) {
+    return new FieldFilterRange(v, Bound.NONE, true, true, false);
+  }
+  /**
+   * Numeric value less than
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeLT(double v) {
+    return new FieldFilterRange(Double.toString(v), Bound.UPPER, true, true, true);
+  }
+  /**
+   * String value less than
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeLT(String v) {
+    return new FieldFilterRange(v, Bound.UPPER, true, true, false);
+  }
+  /**
+   * Numeric value less or equal
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeLE(double v) {
+    return new FieldFilterRange(Double.toString(v), Bound.UPPER, true, false, true);
+  }
+  /**
+   * String value less or equal
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeLE(String v) {
+    return new FieldFilterRange(v, Bound.UPPER, true, false, false);
+  }
+  /**
+   * Numeric value greater than
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeGT(double v) {
+    String sv = Double.toString(v);
+    return new FieldFilterRange(sv, Bound.LOWER, true, true, true);
+  }
+  /**
+   * String value greater than
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeGT(String v) {
+    return new FieldFilterRange(v, Bound.LOWER, true, true, false);
+  }
+  /**
+   * Numeric value greater or equal
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeGE(double v) {
+    String sv = Double.toString(v);
+    return new FieldFilterRange(sv, Bound.LOWER, false, true, true);
+  }
+  /**
+   * String value greater or equal
+   * @param v the test value
+   * @return the test range
+   */
+  static public FieldFilterRange makeGE(String v) {
+    return new FieldFilterRange(v, Bound.LOWER, false, true, false);
+  }
+  /**
+   * The filter test range in appropriate syntax for the remote read engine.
+   * @return the filter string
+   */
+  public String filterExpression() {
+    StringBuilder sb = new StringBuilder(this.values.length*20);
+    if (this.set) { // multiple range entries
+      sb.append((this.number) ? "["  : "['");
+      sb.append(this.values[0]);
+      sb.append((this.number)  ? "]"  : "']");
+      for (int i=1; i<this.values.length; i++) {
+        sb.append((this.number)  ? ",["  : ",['");
+        sb.append(this.values[i]);
+        sb.append((this.number)  ? "]"  : "']");
+      }
+    } else {                                  // single range entry
+      sb.append((this.leftOpen) ? "("  : "[");
+      switch (this.bound) {
+        case BOTH:
+          sb.append((this.number) ? ""  : "'");
+          sb.append(this.values[0]);
+          sb.append((this.number) ? ""  : "'");
+          break;
+        case LOWER:
+          sb.append((this.number) ? ""  : "'");
+          sb.append(this.values[0]);
+          sb.append((this.number) ? ","  : "',");
+          break;
+        case UPPER:
+          sb.append((this.number) ? ","  : ",'");
+          sb.append(this.values[0]);
+          sb.append((this.number) ? ""  : "'");
+          break;
+        default:
+          sb.append((this.number) ? ","  : ",'");
+          sb.append(this.values[0]);
+          sb.append((this.number) ? "),("  : "'),('");
+          sb.append(this.values[0]);
+          sb.append((this.number) ? ","  : "',");
+      }
+      sb.append((this.rightOpen) ? ")"  : "]");
+    }
+    return sb.toString();
+  }
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  public String toString() { return this.filterExpression(); }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/FileFilter.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/FileFilter.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+import java.io.Serializable;
+
+/**
+ * A filter to select records from a file or key.  The filter is conjunction of
+ * field filters with each field having a list of one or more value ranges.
+ *
+ */
+public class FileFilter implements Serializable {
+  public static final long serialVersionUID = 1L;
+  private String filterExpression;
+  /**
+   * A file filter to select records.
+   */
+  public FileFilter(FieldFilter[] fieldFilters) {
+    this.filterExpression = makeExpression(fieldFilters);
+  }
+  /**
+   * A file filter expression to select records, using a string.
+   *
+   * Warning: syntax is not checked.  Use with care.
+   * @param expression a string version of the expression
+   */
+  public FileFilter(String expression) {
+    this.filterExpression = expression;
+  }
+  /**
+   * An empty filter, selects all records
+   */
+  public FileFilter() {
+    this.filterExpression = "";
+  }
+  /**
+   * A null filter which selects all records
+   * @return an empty filter
+   */
+  static public FileFilter nullFilter() {
+    return new FileFilter();
+  }
+  /**
+   * Is this filter empty?
+   * @return true when empty
+   */
+  public boolean isEmpty() { return this.filterExpression.length()==0; }
+  /**
+   * Make the JSON object for the filter expression
+   * @return JSON object as a string (name : expression)
+   */
+  public String toJsonObject() {
+    if (this.isEmpty()) return "";
+    StringBuilder sb = new StringBuilder(this.filterExpression.length() + 30);
+    sb.append("\"keyFilter\"  :  \"");
+    sb.append(this.filterExpression);
+    sb.append("\"");
+    return sb.toString();
+  }
+  /**
+   * Create an expression from an array of FieldFilter objects
+   * @param fieldFilters the field filters
+   * @return a string expression
+   */
+  static private String makeExpression(FieldFilter[] fieldFilters) {
+    StringBuilder sb = new StringBuilder(200*fieldFilters.length);
+    sb.append(fieldFilters[0].filterExpression());
+    for (int i=1; i<fieldFilters.length; i++) {
+      sb.append(",");
+      sb.append(fieldFilters[i].filterExpression());
+    }
+    return sb.toString();
+  }
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/HpccAccessException.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/HpccAccessException.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark.thor;
+
+/**
+ * Non-specific exception accessing the HPCC cluster.
+ */
+public class HpccAccessException extends Exception {
+  static public final long serialVersionUID = 1L;
+  /**
+   * A marker object for an exception during the access of an HPCC based file.
+   */
+  public HpccAccessException() {
+  }
+
+  /**
+   * @param message
+   */
+  public HpccAccessException(String message) {
+    super(message);
+  }
+
+  /**
+   * @param cause
+   */
+  public HpccAccessException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * @param message
+   * @param cause
+   */
+  public HpccAccessException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * @param message
+   * @param cause
+   * @param enableSuppression
+   * @param writableStackTrace
+   */
+  public HpccAccessException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+}

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
@@ -292,9 +292,9 @@ public class PlainConnection {
     sb.append("{ \"format\" : \"binary\",\n");
     sb.append(makeNodeObject());
     sb.append(",\n");
-    sb.append("  \"cursorBin\" : { \"#valuebin\" : \"");
+    sb.append("  \"cursorBin\" : \"");
     sb.append(java.util.Base64.getEncoder().encodeToString(this.cursorBin));
-    sb.append("\" }\n}\n ");
+    sb.append("\" \n}\n");
     return sb.toString();
   }
   /**

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/PlainConnection.java
@@ -18,7 +18,6 @@ package org.hpccsystems.spark.thor;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import org.hpccsystems.spark.FilePart;
 import org.hpccsystems.spark.HpccFileException;
 import org.hpccsystems.spark.RecordDef;
 
@@ -32,7 +31,7 @@ public class PlainConnection {
   private boolean simulateFail;
   private byte[] cursorBin;
   private int handle;
-  private FilePart filePart;
+  private DataPartition dataPart;
   private RecordDef recDef;
   private java.io.DataInputStream dis;
   private java.io.DataOutputStream dos;
@@ -43,12 +42,12 @@ public class PlainConnection {
   private static final byte[] uc_J = "J".getBytes(hpccSet);
   /**
    * A plain socket connect to a THOR node for remote read
-   * @param filePart the remote file name and IP
+   * @param hpccPart the remote file name and IP
    * @param rd the JSON definition for the read input and output
    */
-  public PlainConnection(FilePart fp, RecordDef rd) {
+  public PlainConnection(DataPartition dp, RecordDef rd) {
     this.recDef = rd;
-    this.filePart = fp;
+    this.dataPart = dp;
     this.active = false;
     this.closed = false;
     this.handle = 0;
@@ -59,17 +58,17 @@ public class PlainConnection {
    * The remote file name.
    * @return file name
    */
-  public String getFilename() { return this.filePart.getFilename(); }
+  public String getFilename() { return this.dataPart.getFilename(); }
   /**
    * The primary IP for the file part
    * @return IP address
    */
-  public String getIP() { return this.filePart.getPrimaryIP(); }
+  public String getIP() { return this.dataPart.getPrimaryIP(); }
   /**
    * The port number for the remote read service
    * @return port number
    */
-  public int getPort() { return this.filePart.getClearPort(); }
+  public int getPort() { return this.dataPart.getClearPort(); }
   /**
    * The read transaction in JSON format
    * @return read transaction
@@ -191,7 +190,7 @@ public class PlainConnection {
     this.handle = 0;
     this.cursorBin = new byte[0];
     try {
-      sock = new java.net.Socket(this.getIP(), this.filePart.getClearPort());
+      sock = new java.net.Socket(this.getIP(), this.dataPart.getClearPort());
     } catch (java.net.UnknownHostException e) {
       throw new HpccFileException("Bad file part addr "+this.getIP(), e);
     } catch (java.io.IOException e) {
@@ -222,14 +221,22 @@ public class PlainConnection {
    */
   private String makeInitialRequest() {
     StringBuilder sb = new StringBuilder(50
-        + this.filePart.getFilename().length()
+        + this.dataPart.getFilename().length()
         + this.recDef.getJsonInputDef().length()
         + this.recDef.getJsonOutputDef().length());
     sb.append("{ \"format\" : \"binary\", \"node\" : ");
-    sb.append("{\n \"kind\" : \"diskread\",\n \"fileName\" : \"");
-    sb.append(this.filePart.getFilename());
-    sb.append("\", \n  \"compressed\": \"");
-    sb.append((this.filePart.isCompressed()) ?"true"  :"false");
+    sb.append("{\n \"kind\" : \"");
+    sb.append((this.dataPart.isIndex())? "indexread"  : "diskread");
+    sb.append("\",\n \"fileName\" : \"");
+    sb.append(this.dataPart.getFilename());
+    sb.append("\", \n");
+    if (!this.dataPart.getFilter().isEmpty()) {
+      sb.append(" ");
+      sb.append(this.dataPart.getFilter().toJsonObject());
+      sb.append(",\n");
+    }
+    sb.append(" \"compressed\": \"");
+    sb.append((this.dataPart.isCompressed()) ?"true"  :"false");
     sb.append("\", \n \"input\" : ");
     sb.append(this.recDef.getJsonInputDef());
     sb.append(", \n \"output\" : ");
@@ -250,7 +257,7 @@ public class PlainConnection {
   }
   private String makeCursorRequest() {
     StringBuilder sb = new StringBuilder(80
-        + this.filePart.getFilename().length()
+        + this.dataPart.getFilename().length()
         + this.recDef.getJsonInputDef().length()
         + this.recDef.getJsonOutputDef().length()
         + (int)(this.cursorBin.length*1.4));
@@ -260,10 +267,18 @@ public class PlainConnection {
     sb.append(w);
     sb.append("\" }, ");
     sb.append(" \n \"node\" : ");
-    sb.append("{\n \"kind\" : \"diskread\",\n \"fileName\" : \"");
-    sb.append(this.filePart.getFilename());
-    sb.append("\", \n  \"compressed\": \"");
-    sb.append((this.filePart.isCompressed()) ?"true"  :"false");
+    sb.append("{\n \"kind\" : \"");
+    sb.append((this.dataPart.isIndex())? "indexread"  : "diskread");
+    sb.append("\",\n \"fileName\" : \"");
+    sb.append(this.dataPart.getFilename());
+    sb.append("\", \n");
+    if (!this.dataPart.getFilter().isEmpty()) {
+      sb.append(" ");
+      sb.append(this.dataPart.getFilter().toJsonObject());
+      sb.append(",\n");
+    }
+    sb.append(" \"compressed\": \"");
+    sb.append((this.dataPart.isCompressed()) ?"true"  :"false");
     sb.append("\", \n \"input\" : ");
     sb.append(this.recDef.getJsonInputDef());
     sb.append(", \n \"output\" : ");

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/RemapInfo.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/RemapInfo.java
@@ -31,10 +31,9 @@ public class RemapInfo implements Serializable {
   private final int base_portSsl;
   /**
    * Info to create a null re-map.
-   * @param thorNodes number of THOR nodes in this cluster
    */
-  public RemapInfo(int thorNodes) {
-    this.nodes = thorNodes;
+  public RemapInfo() {
+    this.nodes = 0;
     this.base_portClear = 0;
     this.base_portSsl = 0;
     this.base_ip = "";

--- a/DataAccess/src/main/java/org/hpccsystems/spark/thor/TypeDef.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/thor/TypeDef.java
@@ -26,6 +26,17 @@ import com.fasterxml.jackson.core.JsonToken;
 
 public class TypeDef implements Serializable {
   static final long serialVersionUID = 1L;
+  // Inner tpe for returning revision information
+  static public class Revision {
+    final public long revisedType;
+    final public long revisedLength;
+    final public boolean revised;
+    public Revision(long typ, long len, boolean rev) {
+      this.revisedType = typ;
+      this.revisedLength = len;
+      this.revised = rev;
+    }
+  }
   private FieldType type;
   private String typeName;
   private int len;
@@ -33,51 +44,81 @@ public class TypeDef implements Serializable {
   private FieldDef[] struct;
   private boolean unsignedFlag;
   private boolean fixedLength;
+  private boolean payload;
   private int childLen;
   private FieldType childType;
   private HpccSrcType childSrc;
   // flag values from eclhelper.hpp RtlFieldTypeMask enum definition
-  final private static short flag_unsigned = 256;
-  final private static short flag_unknownsize = 1024;
+  final private static int flag_unsigned = 256;
+  final private static int flag_ebcdic = 256;         // only if string type
+  final private static int flag_unknownsize = 1024;
+  final private static int flag_biased = 8192;
+  final private static int flag_payload = 65536;
+  final private static int flag_ebcdic_pd = 131072;
   // type codes from rtlconst.hpp type_vals enum definition
-  final private static short type_boolean = 0;
-  final private static short type_int = 1;
-  final private static short type_real = 2;
-  final private static short type_string = 4;
-  final private static short type_record = 13;
-  final private static short type_varstring = 14;
-  final private static short type_table = 20;
-  final private static short type_set = 21;
-  final private static short type_unicode = 31;
-  final private static short type_varunicode = 33;
-  final private static short type_utf8 = 41;
-  final private static short type_uint = flag_unsigned + type_int;
-  final private static short type_vrecord = flag_unknownsize + type_record;
-  final private static short type_vtable = flag_unknownsize + type_table;
-  final private static short type_vstring = flag_unknownsize + type_string;
-  final private static short type_vset = flag_unknownsize + type_set;
-  final private static short type_vunicode = flag_unknownsize + type_unicode;
-  final private static short type_vutf8 = flag_unknownsize + type_utf8;
+  final private static int type_boolean = 0;
+  final private static int type_int = 1;
+  final private static int type_real = 2;
+  final private static int type_decimal = 3;
+  final private static int type_string = 4;       // blot EBCDIC flag if on
+  final private static int type_alias = 5;        // Dropped
+  final private static int type_date = 6;         // Dropped
+  final private static int type_swapfilepos = 7;  // Dropped
+  final private static int type_biasedswapint = 8;// Convert to integer
+  final private static int type_bitfield = 9;     // Dropped
+  final private static int type_keyedint = 10;    // Convert to integer
+  final private static int type_char = 11;        // Convert to string
+  final private static int type_enumerated = 12;  // Dropped
+  final private static int type_record = 13;
+  final private static int type_varstring = 14;
+  final private static int type_blob = 15;        // Dropped
+  final private static int type_data = 16;
+  final private static int type_pointer = 17;     // Dropped
+  final private static int type_class = 18;       // Dropped
+  final private static int type_array = 19;       // Dropped
+  final private static int type_table = 20;
+  final private static int type_set = 21;
+  final private static int type_row = 22;         // Dropped
+  final private static int type_groupedtable = 23;// Dropped
+  final private static int type_void = 24;        // Dropped
+  final private static int type_alien = 25;       // Dropped
+  final private static int type_swapint = 26;     // Convert to integer
+  final private static int type_none = 27;        // Dropped
+  final private static int type_packedint = 28;   // Dropped
+  final private static int type_filepos = 29;
+  final private static int type_qstring = 30;     // Convert to string
+  final private static int type_unicode = 31;
+  final private static int type_any = 32;         // Dropped
+  final private static int type_varunicode = 33;
+  final private static int type_pattern = 34;     // Dropped
+  final private static int type_rule = 35;        // Dropped
+  final private static int type_token = 36;       // Dropped
+  final private static int type_feature = 37;     // Dropped
+  final private static int type_event = 38;       // Dropped
+  final private static int type_null = 39;        // Dropped
+  final private static int type_scope = 40;       // Dropped
+  final private static int type_utf8 = 41;
+  final private static int type_transform = 42;   // Dropped
+  final private static int type_ifblock = 43;     // Dropped
+  final private static int type_function = 44;    // Dropped
+  final private static int type_sortlist = 45;    // Dropped
+  final private static int type_dictionary = 46;  // Dropped
+  // End of known range of types
+  final private static int type_max = 46;
+  // Combinations
+  final private static int type_uint = flag_unsigned + type_int;
+  final private static int type_ufilepos = flag_unsigned + type_filepos;
+  final private static int type_vrecord = flag_unknownsize + type_record;
+  final private static int type_vtable = flag_unknownsize + type_table;
+  final private static int type_vstring = flag_unknownsize + type_string;
+  final private static int type_vset = flag_unknownsize + type_set;
+  final private static int type_vunicode = flag_unknownsize + type_unicode;
+  final private static int type_vutf8 = flag_unknownsize + type_utf8;
   // JSON pair names of interest
   final private static String fieldTypeName = "fieldType";
   final private static String lengthName = "length";
   final private static String childName = "child";
   final private static String fieldsName = "fields";
-  /**
-   * Private constructor for dummy child object and serialization support.
-   */
-  protected TypeDef() {
-    this.typeName = "none";
-    this.len = 0;
-    this.src = HpccSrcType.UNKNOWN;
-    this.type = FieldType.MISSING;
-    this.struct = new FieldDef[0];
-    this.childLen = 0;
-    this.childSrc = HpccSrcType.UNKNOWN;
-    this.childType = FieldType.MISSING;
-    this.unsignedFlag = false;
-    this.fixedLength = false;
-  }
   /**
    * Normal constructor to use when this definition describes a structure
    * @param type the value of the JSON pair named fieldType
@@ -91,14 +132,16 @@ public class TypeDef implements Serializable {
   public TypeDef(long type_id, String typeName, int len,
       FieldType childType, int childLen, HpccSrcType childSrc,
       FieldDef[] defs) {
-    short type = (type_id < 10000) ? (short) type_id   : -1;
+    this.payload = (type_id & flag_payload) != 0;
+    int type = (int) (type_id & 0x7fff);
     this.typeName = typeName;
     this.len = len;
     this.struct = defs;
-    this.unsignedFlag = type==type_uint;
+    this.unsignedFlag = (type_id & 0x0100) != 0;
     this.childLen = childLen;
     this.childSrc = childSrc;
     this.childType = childType;
+    // Pick up FieldType and length
     switch (type) {
       case type_boolean:
         this.fixedLength = true;
@@ -106,6 +149,8 @@ public class TypeDef implements Serializable {
         break;
       case type_int:
       case type_uint:
+      case type_filepos:
+      case type_ufilepos:
         this.fixedLength = true;
         this.type = FieldType.INTEGER;
         break;
@@ -114,6 +159,7 @@ public class TypeDef implements Serializable {
         this.type = FieldType.REAL;
         break;
       case type_string:
+      case type_char:
       case type_unicode:
         this.fixedLength = true;
         this.type = FieldType.STRING;
@@ -181,11 +227,16 @@ public class TypeDef implements Serializable {
         this.fixedLength = false;
         this.type = FieldType.MISSING;
     }
+    // Pick up source type
     switch (type) {
       case type_int:
       case type_uint:
       case type_real:
         this.src = HpccSrcType.LITTLE_ENDIAN;
+        break;
+      case type_filepos:
+      case type_ufilepos:
+        this.src = HpccSrcType.BIG_ENDIAN;
         break;
       case type_utf8:
       case type_vutf8:
@@ -254,7 +305,13 @@ public class TypeDef implements Serializable {
   /**
    * Is the numeric value an unsigned value?
    */
-  public boolean isUnsigned() { return unsignedFlag; }
+  public boolean isUnsigned() { return this.unsignedFlag; }
+  /**
+   * Is this a payload field in an index
+   * @return yes
+   */
+  public boolean isPayload() { return this.payload; }
+
   /**
    * Is the field a fixed length?
    */
@@ -273,11 +330,18 @@ public class TypeDef implements Serializable {
    */
   public HpccSrcType getSourceType() { return this.src; }
   /**
+   * Can we support a read of this type of data?
+   * @return true if this type is unsupported
+   */
+  public boolean isUnsupported() {
+    return this.src==HpccSrcType.UNKNOWN || this.type==FieldType.MISSING;
+  }
+  /**
    * Pick up a type definition from parsing a JSON string.  The type
    * definitions are object pairs.  The type definition object has pair
    * members named fieldType, length, child, and fields.  A fields pair
    * is an array of field definitions.
-   * @param curr the START_OBJECT token that starts the definition
+   * @param first the START_OBJECT token that starts the definition
    * @param toks_iter iterator of the tokens making up a JSON string
    * @param type_dict a dictionary of the types previously defined
    * @return the type definition from the tokens
@@ -354,5 +418,108 @@ public class TypeDef implements Serializable {
     TypeDef rslt = new TypeDef(fieldType, typeName, length, childType,
         childLen, childSrc, fields);
     return rslt;
+  }
+  /**
+   * Create a revision type or a copy of input if no revision required
+   * @param typ the field type from the type definition
+   * @param len the field length from the type definition
+   * @return a revision or a copy if not revised
+   */
+  public static Revision getRevision(long typ, long len) {
+    long unsigned_flag = typ & flag_unsigned;
+    long unknown_size = typ & flag_unknownsize;
+    long revisedType = typ;
+    long revisedLength = len;
+    boolean revised = false;
+    int typAlone = ((int)typ) & 0xff;
+    switch (typAlone) {
+    case type_decimal:
+      revisedType = type_real;
+      revisedLength = 8;
+      revised = true;
+      break;
+    case type_biasedswapint:
+      revisedType = type_int + unsigned_flag;
+      revised = true;
+      break;
+    case type_keyedint:
+      revisedType = type_int + unsigned_flag;
+      revised = true;
+      break;
+    case type_char:
+      revisedType = type_string;
+      revisedLength = 1;
+      revised = true;
+      break;
+    case type_swapint:
+      revisedType = type_int + unsigned_flag;
+      revised = true;
+      break;
+    case type_qstring:
+      revisedType = type_string;
+      revised = true;
+      break;
+    default:
+      break;
+    }
+    return new Revision(revisedType, revisedLength, revised);
+  }
+  /**
+   * Revise the Flag value (type information) as required
+   * @param flag the value from the field definition
+   * @return the revised flag value reflaection the type
+   */
+  public static long reviseFlags(long flag) {
+    long unsigned_value = ( flag & flag_unsigned);
+    long payload_value = (flag & flag_payload);
+    int typAlone = ((int)flag) & 0xff;
+    Revision rt = getRevision(typAlone, 0);
+    long rslt = rt.revisedType + unsigned_value + payload_value;
+    return rslt;
+  }
+  /**
+   * Is this type private to the HPCC Cluster?
+   * @param typ suppress when true
+   * @return
+   */
+  public static boolean suppressType(long typ) {
+    int typAlone = ((int)typ) & 0x7F;
+    switch (typAlone) {
+      case type_alias:
+      case type_date:
+      case type_swapfilepos:
+      case type_biasedswapint:
+      case type_bitfield:
+      case type_enumerated:
+      case type_blob:
+      case type_data:
+      case type_pointer:
+      case type_class:
+      case type_array:
+      case type_row:
+      case type_groupedtable:
+      case type_void:
+      case type_alien:
+      case type_none:
+      case type_packedint:
+      case type_any:
+      case type_pattern:
+      case type_rule:
+      case type_token:
+      case type_feature:
+      case type_event:
+      case type_null:
+      case type_scope:
+      case type_transform:
+      case type_ifblock:
+      case type_function:
+      case type_sortlist:
+      case type_dictionary:
+        return true;
+      default:
+        if (typAlone < 0 || typAlone > type_max) return true;
+        break;
+    }
+    return false;
   }
 }

--- a/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/DataframeTest.java
@@ -70,15 +70,15 @@ public class DataframeTest {
     String base_ip = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList, 0);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
       hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,
-          fieldList, ri);
+          fieldList, ri, 0);
     }
     System.out.println("Getting file parts");
-    FilePart[] parts = hpcc.getFileParts();
-    for (FilePart p : parts) System.out.println(p.toString());
+    HpccPart[] parts = hpcc.getFileParts();
+    for (HpccPart p : parts) System.out.println(p.toString());
     System.out.println("Getting record definition");
     RecordDef rd = hpcc.getRecordDefinition();
     System.out.println(rd.toString());

--- a/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
@@ -95,7 +95,9 @@ public class HpccFileTest {
     System.out.println(pc.getIP());
     System.out.println(pc.getFilename());
     //pc.setSimulateFail(true);
+    pc.setForceCursorUse(true);
     boolean wantData = true;
+    int block_limit = 4;
     while (wantData) {
       byte[] block = pc.readBlock();
       StringBuilder sb = new StringBuilder();
@@ -121,7 +123,7 @@ public class HpccFileTest {
         System.out.println("CursorBin transaction is: ");
         System.out.println(pc.getCursorTrans());
       }
-      wantData = block.length > 0;
+      wantData = block.length > 0 && block_limit-- > 0;
     }
     System.out.println("End test");
   }

--- a/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/HpccFileTest.java
@@ -95,7 +95,7 @@ public class HpccFileTest {
     System.out.println(pc.getIP());
     System.out.println(pc.getFilename());
     //pc.setSimulateFail(true);
-    pc.setForceCursorUse(true);
+    //pc.setForceCursorUse(true);
     boolean wantData = true;
     int block_limit = 4;
     while (wantData) {

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RDDTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RDDTest.java
@@ -79,14 +79,14 @@ public class RDDTest {
     String base_ip = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList);
+      hpcc = new HpccFile(testName,protocol,esp_ip,port,user,pword,fieldList,0);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
       hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,
-          fieldList, ri);
+          fieldList, ri, 0);
     }
     System.out.println("Getting file parts");
-    FilePart[] parts = hpcc.getFileParts();
+    HpccPart[] parts = hpcc.getFileParts();
     System.out.println("Getting record definition");
     RecordDef rd = hpcc.getRecordDefinition();
     System.out.println(rd.toString());

--- a/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/RecordTest.java
@@ -5,7 +5,9 @@ import java.io.InputStreamReader;
 import java.util.Iterator;
 
 import org.hpccsystems.spark.thor.BinaryRecordReader;
+import org.hpccsystems.spark.thor.DataPartition;
 import org.hpccsystems.spark.thor.FieldDef;
+import org.hpccsystems.spark.thor.FileFilter;
 import org.hpccsystems.spark.thor.RemapInfo;
 
 public class RecordTest {
@@ -33,6 +35,9 @@ public class RecordTest {
     System.out.print("Field list or empty: ");
     System.out.flush();
     String fieldList = br.readLine();
+    System.out.print("File filter expression or empty: ");
+    System.out.flush();
+    String filterExpression = br.readLine();
     System.out.print("Number of nodes for remap or empty: ");
     System.out.flush();
     String nodes = br.readLine();
@@ -41,19 +46,20 @@ public class RecordTest {
     String base_ip = br.readLine();
     HpccFile hpcc;
     if (nodes.equals("") || base_ip.equals("")) {
-      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList);
+      hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword, fieldList,
+                          new FileFilter(filterExpression), 0);
     } else {
       RemapInfo ri = new RemapInfo(Integer.parseInt(nodes), base_ip);
       hpcc = new HpccFile(testName, protocol, esp_ip, port, user, pword,
-          fieldList, ri);
+          fieldList, new FileFilter(filterExpression), ri, 0);
     }
     System.out.println("Getting file parts");
-    FilePart[] parts = hpcc.getFileParts();
+    HpccPart[] parts = hpcc.getFileParts();
     for (int i=0; i<parts.length; i++) {
-      System.out.println(parts[i].getFilename() + ":"
-              + parts[i].getPrimaryIP()+ ":"
-              + parts[i].getSecondaryIP() + ": "
-              + parts[i].getThisPart());
+      System.out.println(parts[i].getPartitionInfo().getFilename() + ":"
+              + parts[i].getPartitionInfo().getPrimaryIP()+ ":"
+              + parts[i].getPartitionInfo().getSecondaryIP() + ": "
+              + parts[i].getPartitionInfo().getThisPart());
     }
     System.out.println("Getting record definition");
     RecordDef rd = hpcc.getRecordDefinition();
@@ -66,7 +72,8 @@ public class RecordTest {
     for (int i=0; i<parts.length; i++) {
       System.out.println("Reading records from part index " + i);
       try {
-        BinaryRecordReader brr = new BinaryRecordReader(parts[i], rd);
+        DataPartition dp = parts[i].getPartitionInfo();
+        BinaryRecordReader brr = new BinaryRecordReader(dp, rd);
         while (brr.hasNext()) {
           Record rec = brr.getNext();
           System.out.println(rec.toString());
@@ -75,11 +82,11 @@ public class RecordTest {
       } catch (Exception e) {
         StringBuilder sb = new StringBuilder();
         sb.append("Failed for part ");
-        sb.append(parts[i].getThisPart());
+        sb.append(parts[i].getPartitionInfo().getThisPart());
         sb.append(" to ");
-        sb.append(parts[i].getPrimaryIP());
+        sb.append(parts[i].getPartitionInfo().getPrimaryIP());
         sb.append(":");
-        sb.append(parts[i].getClearPort());
+        sb.append(parts[i].getPartitionInfo().getClearPort());
         sb.append(" with error ");
         sb.append(e.getMessage());
         System.out.println(sb.toString());


### PR DESCRIPTION
Reads index datasets with filtering.  Increased the number of datatypes supported and suppressed datatypes that should not be supported.  Indexes have an additional file part, so the relationship between Spark partitions and file parts was made indirect.

ColumnPruner was enhanced to suppress datatypes that are unsupported and to change the output format of particular types (like QSTRING) into a more standard type.  The enhancement eliminated shortcut processing through the ColumnPruner.

HpccDataFrameFactory was modified to use the replacement of FilePart with HpccPart.

HpccFile was enhanced by adding several convenience constructors and by adding the display of the JSON layout definition in the event of a problem processing the definition.  The FilePart object was refactored into an HpccPart object employed by HpccFile and a DataPart object.

HpccPart is the result of refactoring FilePart to make the relationship between Spark partitions and Thor file partitions indirect.

HpccRDD was modified to use the replacement of FilePart with HpccPart.

HpccRemoteFileReader was modified to use the new HpccPart.

package-info updated to reflect the change in class name of FilePart to HpccPart.

AddrRemapper was enhanced to work in cases where there are more file parts than nodes.  Cleaned up the implementation to get a list of the unique IP values instead of assuming that the IP values were unique.

BinaryRecordReader was modified to use the DataPart object that was refactored from the FilePart.

ClusterRemapper was modified to remove the number of parts.

DataPartition was created by refactoring FilePart.

DefEntry removed unused constructor and added tracking of type, length, and type flag.  The short cut processing for the no pruning case was removed.

DefEntryField was modified to track if the definition should be suppressed; or if the definition had been modified.  An unused empty constructor was removed.

DefEntryRoot was modified to remove an unused constructor and to track suppressions and type changes.

DefEntryType was modified to remove an unused constructor and to track suppression and type changes.

DefToken was enhanced by adding comments and a new constructor used for the update of type and length information.

FieldFilter class was added to capture filter criteria for a specified field name.  the constructor takes FieldFilterRanges.

FieldFilterRange class capture the properties for a filter range.

FileFilter class was added to capture filter information from either an array of FieldFilter objects or a string version of the filter expression.

PlainConnection updated for the FilePart refactor.  Updated to request an index read instead of a disk read when the file is an index, and updated to add the field filter to the read request.

RemapInfo was updated to use zero nodes for the empty constructor.

TypeDef was enhanced to support type revision and suppression.

DataframeTest was updated for the FilePart refactor.

HpccFiletest was updated for the FilePart refactor and to add file filtering and to allow the user to specify which part to read.

RDDTest was updated for the FilePart refactor.

RecordTest was updated to support Field filters and the FilePart refactor.