### PR TITLE
HPCC-21706 Re-partitioning fails when writing to HPCC from Spark

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccFileWriter.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccFileWriter.java
@@ -181,7 +181,7 @@ public class HpccFileWriter implements Serializable
 
         if (hpccPartitions.length != rdd.getNumPartitions())
         {
-            rdd.repartition(hpccPartitions.length);
+            rdd = rdd.repartition(hpccPartitions.length);
             if (rdd.getNumPartitions() != hpccPartitions.length)
             {
                 throw new Exception("Repartitioning RDD failed. Aborting write.");


### PR DESCRIPTION
- Corrected repartitioning code

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>