### PR TITLE
HPCC-21797 Add missing PySpark to Spark Row & Schema conversion functions

### DIFF
--- a/DataAccess/pom.xml
+++ b/DataAccess/pom.xml
@@ -160,6 +160,12 @@
             <artifactId>dfsclient</artifactId>
             <version>7.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.razorvine</groupId>
+            <artifactId>pyrolite</artifactId>
+            <version>[4.13,)</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <developers>
         <developer>

--- a/DataAccess/src/main/java/org/hpccsystems/spark/RowConstructor.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/RowConstructor.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.spark;
+
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+
+import net.razorvine.pickle.IObjectConstructor;
+import net.razorvine.pickle.PickleException;
+
+public class RowConstructor implements IObjectConstructor {
+
+    public RowConstructor() {}
+
+    @Override
+    public Object construct(Object[] tupleFields) throws PickleException
+    {
+        // PySpark Rows consist of two properties. An ArrayList of field names and Object[] array of field values.
+        if (tupleFields.length != 2)
+        {
+            throw new PickleException("Unexpected Row data layout.");
+        }
+
+        Object[] rowFields = (Object[]) tupleFields[1];
+        return new GenericRowWithSchema(rowFields,null);
+    }
+}


### PR DESCRIPTION

- Added custom Unpickler constructor for PySpark Rows
- Created an inferSchema method to generate a valid Java Spark Schema
- Added a new saveToHPCC that allows the user to specify the Spark Schema instead of using the Schema from the RDD rows

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>