### PR TITLE
HPCC-21797 Add missing PySpark to Spark Row & Schema conversion function

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/PySparkField.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/PySparkField.java
@@ -15,26 +15,24 @@
  *******************************************************************************/
 package org.hpccsystems.spark;
 
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
-
-import net.razorvine.pickle.IObjectConstructor;
-import net.razorvine.pickle.PickleException;
-
-public class RowConstructor implements IObjectConstructor
+public class PySparkField 
 {
+    private String name = null;
+    private Object value = null; 
 
-    public RowConstructor() {}
-
-    @Override
-    public Object construct(Object[] tupleFields) throws PickleException
+    public PySparkField(String n, Object v)
     {
-        // PySpark Rows consist of two properties. An ArrayList of field names and Object[] array of field values.
-        if (tupleFields.length != 2)
-        {
-            throw new PickleException("Unexpected Row data layout.");
-        }
+        name = n;
+        value = v;
+    }
 
-        Object[] rowFields = (Object[]) tupleFields[1];
-        return new GenericRowWithSchema(rowFields,null);
+    public String getName()
+    {
+        return name;
+    }
+
+    public Object getValue()
+    {
+        return value;
     }
 }

--- a/DataAccess/src/main/java/org/hpccsystems/spark/PySparkFieldConstructor.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/PySparkFieldConstructor.java
@@ -15,26 +15,25 @@
  *******************************************************************************/
 package org.hpccsystems.spark;
 
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
-
 import net.razorvine.pickle.IObjectConstructor;
 import net.razorvine.pickle.PickleException;
 
-public class RowConstructor implements IObjectConstructor
+public class PySparkFieldConstructor implements IObjectConstructor
 {
 
-    public RowConstructor() {}
+    public PySparkFieldConstructor() {}
 
     @Override
     public Object construct(Object[] tupleFields) throws PickleException
     {
-        // PySpark Rows consist of two properties. An ArrayList of field names and Object[] array of field values.
-        if (tupleFields.length != 2)
+        // PySparkFields consist of two fields Name & Value
+        if (tupleFields.length != 2 || tupleFields[0] instanceof String == false)
         {
-            throw new PickleException("Unexpected Row data layout.");
+            throw new PickleException("Unexpected PySparkField data layout.");
         }
 
-        Object[] rowFields = (Object[]) tupleFields[1];
-        return new GenericRowWithSchema(rowFields,null);
+        String name = (String) tupleFields[0];
+        Object value = (Object) tupleFields[1];
+        return new PySparkField(name,value);
     }
 }


### PR DESCRIPTION

- Modified inferSchema to maintain field order

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>