### PR TITLE
HPCC-22049 Spark-HPCC: Converting an RDD with child datasets to a dataframe fails

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/GenericRowRecordAccessor.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/GenericRowRecordAccessor.java
@@ -18,6 +18,9 @@ package org.hpccsystems.spark;
 
 import org.hpccsystems.dfs.client.IRecordAccessor;
 
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
 import org.hpccsystems.commons.ecl.FieldDef;
 import org.hpccsystems.commons.ecl.FieldType;
 
@@ -82,7 +85,16 @@ public class GenericRowRecordAccessor implements IRecordAccessor
 
     public Object getFieldValue(int index)
     {
-        return this.row.get(index);
+        Object value = this.row.get(index);
+        if (value instanceof Seq)
+        {
+            Seq seqValue = (Seq) value;
+            return JavaConverters.seqAsJavaListConverter(seqValue).asJava();
+        }
+        else
+        {
+            return value;
+        }
     }
 
     public FieldDef getFieldDefinition(int index)

--- a/DataAccess/src/main/java/org/hpccsystems/spark/GenericRowRecordBuilder.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/GenericRowRecordBuilder.java
@@ -20,8 +20,13 @@ import org.hpccsystems.dfs.client.IRecordBuilder;
 
 import org.hpccsystems.commons.ecl.FieldDef;
 import org.hpccsystems.commons.ecl.FieldType;
+
+import java.util.List;
+
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.types.*;
+
+import scala.collection.JavaConverters;
 
 public class GenericRowRecordBuilder implements IRecordBuilder
 {
@@ -87,7 +92,15 @@ public class GenericRowRecordBuilder implements IRecordBuilder
 
     public void setFieldValue(int index, Object value) throws IllegalArgumentException, IllegalAccessException
     {
-        this.fields[index] = value;
+        if (value instanceof List)
+        {
+            List<Object> listVal = (List<Object>) value;
+            this.fields[index] = JavaConverters.asScalaIteratorConverter(listVal.iterator()).asScala().toSeq();
+        }
+        else
+        {
+            this.fields[index] = value;
+        }
     }
 
     public IRecordBuilder getChildRecordBuilder(int index)

--- a/DataAccess/src/main/java/org/hpccsystems/spark/HpccRDD.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/HpccRDD.java
@@ -210,7 +210,7 @@ public class HpccRDD extends RDD<Row> implements Serializable
     public Seq<String> getPreferredLocations(Partition split)
     {
         final InternalPartition part = (InternalPartition) split;
-        return JavaConverters.asScalaBufferConverter(Arrays.asList(part.partition.getCopyLocations())).asScala().seq();
+        return JavaConverters.asScalaBufferConverter(Arrays.asList(part.partition.getCopyLocations()[0])).asScala().seq();
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION

- Modified GenericRowRecordAccessor / GenericRowRecordBuilder to handle conversion between Scala.Seq and Java ArrayList

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>