### PR TITLE
Updated pom for 7.2.16 release

### DIFF
--- a/DataAccess/pom.xml
+++ b/DataAccess/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hpccsystems</groupId>
     <artifactId>spark-hpcc</artifactId>
-    <version>7.2.8-SNAPSHOT</version>
+    <version>7.2.16</version>
     <name>spark-hpcc</name>
     <description>RDD for reading files residing in an HPCC cluster environment</description>
     <url>https://hpccsystems.com</url>
@@ -148,17 +148,17 @@
         <dependency>
             <groupId>org.hpccsystems</groupId>
             <artifactId>commons-hpcc</artifactId>
-            <version>1.0.8-SNAPSHOT</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.hpccsystems</groupId>
             <artifactId>wsclient</artifactId>
-            <version>7.2.8-SNAPSHOT</version>
+            <version>7.2.16</version>
         </dependency>
         <dependency>
             <groupId>org.hpccsystems</groupId>
             <artifactId>dfsclient</artifactId>
-            <version>7.2.8-SNAPSHOT</version>
+            <version>7.2.16</version>
         </dependency>
         <dependency>
             <groupId>net.razorvine</groupId>


### PR DESCRIPTION
Signed-off-by: Michael Gardner <michael.gardner@lexisnexisrisk.com>

@richardkchapman 
Updated the dependencies for their new gold releases.  Updated the main version to 7.2.16.  Currently it's based off Master, but if you could please make a candidate-7.2.16 branch, I'll rebase it on that.  