### PR TITLE
HPCC-22509 Update to spark-core 2.4.1

### DIFF
--- a/DataAccess/pom.xml
+++ b/DataAccess/pom.xml
@@ -133,12 +133,12 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_2.11</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.1</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>


### PR DESCRIPTION
- Updating to anything newer than 2.4.1 caused build/junit time issues
-- IOException when zipping org/xerial/snappy/BitShuffle.class: invalid LOC header

Signed-off-by: Pastrana, Rodrigo <rodrigo.pastrana@lexisnexis.com>