### PR TITLE
HPCC4J-400 Update spark library dependancies

### DIFF
--- a/DataAccess/README.md
+++ b/DataAccess/README.md
@@ -1,9 +1,6 @@
 # Spark-HPCC/DataAccess
-Spark classes for working with HPCC clusters
+Spark-based classes for HPCC Systems/ Spark interoperability
 
-This is an early release version.
+HPCC Systems platform target runtime must be 7.x or newer
 
-You must be running on a 7.x platform version.
-
-You also need a 2.x-release version of the JAPI wsclient jar,
-which can be built from the current master branch.
+HPCC4J wsclient, dfsclient, and commons-hpcc build dependencies must be 7.x or newer.

--- a/DataAccess/pom.xml
+++ b/DataAccess/pom.xml
@@ -23,6 +23,7 @@
     <maven.javadoc.version>3.1.0</maven.javadoc.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <spark.runtime.version>2.4.6</spark.runtime.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javadoc.excludePackageNames></javadoc.excludePackageNames>
     <groups>org.hpccsystems.commons.annotations.BaseTests</groups>
@@ -43,12 +44,14 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
-      <version>2.4.1</version>
+      <version>${spark.runtime.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.11</artifactId>
-      <version>2.4.1</version>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>${spark.runtime.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/README.md
+++ b/README.md
@@ -1,24 +1,32 @@
 ![HPCC Spark Connector Nightly](https://github.com/hpcc-systems/spark-hpcc/workflows/HPCC%20Spark%20Connector%20Nightly/badge.svg)
+[![javadoc](https://javadoc-badge.appspot.com/org.hpccsystems/spark-hpcc.svg?label=javadoc)](https://javadoc-badge.appspot.com/org.hpccsystems/spark-hpcc)
 
 ##### Current Maven Central Releases:
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.hpccsystems/spark-hpcc/badge.svg?subject=spark-hpcc)](https://maven-badges.herokuapp.com/maven-central/org.hpccsystems/spark-hpcc)
 
 # Spark-HPCC
-Spark classes for working with HPCC clusters
+Spark classes for HPCC Systems/ Spark interoperability
 
-There are two projects, DataAccess and Examples.
+This repository is comprised of two projects, DataAccess and Examples.
 
-The DataAccess project contains the classes to support
-reading data from a THOR cluster with a Spark RDD.  In
-addition, te HPCC data is exposed as a Dataframe for
-the convenience of the Spark developer.
+###DataAccess
+The DataAccess project contains the classes which expose distributed
+streaming of HPCC based data via Spark constructs. In addition,
+the HPCC data is exposed as a Dataframe for the convenience of the Spark developer.
 
+####Dependancies
+The spark-hpcc target jar does not package any of the Spark libraries it depends on.
+If using a standard Spark submission pipeline such as spark-submit these dependencies will be provided as part of the Spark installation.
+However, if your pipeline executes a jar directly you may need to add the Spark libraries from your $SPARK_HOME to the classpath.
+
+###Examples
 The Examples project contains examples in Scala for
 using HPCC THOR cluster based data in a Machine
 Learning application.
 
-Please note:
-As reported by github: 
+##Please note:
+#####As reported by github:
+
 "In all versions of Apache Spark, its standalone resource manager accepts code to execute on a 'master' host, that then runs that code on 'worker' hosts. The master itself does not, by design, execute user code. A specially-crafted request to the master can, however, cause the master to execute code too. Note that this does not affect standalone clusters with authentication enabled. While the master host typically has less outbound access to other resources than a worker, the execution of code on the master is nevertheless unexpected.
 Mitigation
 


### PR DESCRIPTION
- Labels spark library dependancies as provided
- Updates spark lib dep to 2.4.6
- Removes spark ml deps
- Updates readmes

Signed-off-by: Rodrigo Pastrana <Rodrigo.Pastrana@lexisnexisrisk.com>