### PR TITLE
Bump log4j-core from 2.17.0 to 2.17.1 in /DataAccess

### DIFF
--- a/DataAccess/pom.xml
+++ b/DataAccess/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
       <type>pom</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps log4j-core from 2.17.0 to 2.17.1.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>