### PR TITLE
HPCC4J-523 Incorrect Java version linking based on JDK

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -3,7 +3,7 @@ name: HPCC Spark Connector Nightly
 on:
   schedule:
   - cron: "0 2 * * 1-5"
-  
+
 jobs:
   build:
 
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn -B package --file DataAccess/pom.xml

--- a/.github/workflows/SparkConnectorPRBuild.yml
+++ b/.github/workflows/SparkConnectorPRBuild.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn -B package --file DataAccess/pom.xml

--- a/.github/workflows/javadocTest.yml
+++ b/.github/workflows/javadocTest.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup JDK 1.8
+    - name: Setup JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     # speed things up with caching from https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven
     - name: Cache Maven packages

--- a/.github/workflows/sparkRemoteUnitTests.yml
+++ b/.github/workflows/sparkRemoteUnitTests.yml
@@ -1,6 +1,6 @@
 name: Spark-HPCC remote unit tests
 
-on: 
+on:
   pull_request:
     branches:
       - "master"
@@ -25,13 +25,13 @@ jobs:
           - 8080:8080
 
     steps:
-      
+
     - uses: actions/checkout@v2
 
-    - name: Setup JDK 1.8
+    - name: Setup JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Fetch hpccsystems-platform docker container name
       run: |
@@ -44,7 +44,7 @@ jobs:
     - name: HPCCSystems Startup
       run: |
         docker exec ${{ env.PLATFORM_CONTAINER_NAME }} /etc/init.d/hpcc-init start
-    
+
     - name: HPCCSystems Certificate Setup
       run: |
         docker exec ${{ env.PLATFORM_CONTAINER_NAME }} /opt/HPCCSystems/etc/init.d/distributePKI
@@ -55,7 +55,7 @@ jobs:
         chmod +x generatedata.sh
         docker cp generatedata.sh ${{ env.PLATFORM_CONTAINER_NAME }}:/home/hpcc/generatedata.sh
         docker exec ${{ env.PLATFORM_CONTAINER_NAME }} /home/hpcc/generatedata.sh
-    
+
     # speed things up with caching from https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven
     - name: Cache Maven packages
       uses: actions/cache@v2
@@ -63,6 +63,6 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-  
+
     - name: Build with Maven
       run: mvn -B -f DataAccess/pom.xml --activate-profiles allow-snapshots,jenkins-on-demand -Dmaven.gpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.test.failure.ignore=false install

--- a/.github/workflows/sparkconnectorbuildonmerge.yml
+++ b/.github/workflows/sparkconnectorbuildonmerge.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn -B package --file DataAccess/pom.xml

--- a/DataAccess/pom.xml
+++ b/DataAccess/pom.xml
@@ -21,8 +21,8 @@
     <maven.gpg.skip>true</maven.gpg.skip>
     <maven.source.version>2.2.1</maven.source.version>
     <maven.javadoc.version>3.1.0</maven.javadoc.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.version>3.8.0</maven.compiler.version>
+    <maven.compiler.release>8</maven.compiler.release>
     <spark.runtime.version>2.4.6</spark.runtime.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javadoc.excludePackageNames>net.razorvine.*:org.apache.*:org.hpccsystems.commons.*:org.hpccsystems.generated.*:org.hpccsystems.dfs.*:org.hpccsystems.ws.*:org.hpccsystems.ws.client.antlr.*</javadoc.excludePackageNames>
@@ -85,6 +85,13 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven.compiler.version}</version>
+          <configuration>
+            <release>${maven.compiler.release}</release>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>${maven.gpg.version}</version>
@@ -134,7 +141,14 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins> 
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.compiler.version}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven.surefire.version}</version>


### PR DESCRIPTION
- Updated POM file to use release configuration
- Updated Github actions to use JDK 11 required by release build feature

Signed-off-by: James McMullan James.McMullan@lexisnexis.com