### PR TITLE
HPCC4J-615 Expose the UseTLK option from DFSClient

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/datasource/HpccOptions.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/datasource/HpccOptions.java
@@ -18,6 +18,7 @@ public class HpccOptions
     public String               filterString   = null;
     public int                  expirySeconds  = 120;
     public int                  filePartLimit  = -1;
+    public boolean              useTLK         = false;
 
     public HpccOptions(TreeMap<String, String> parameters) throws Exception
     {
@@ -70,6 +71,12 @@ public class HpccOptions
         if (parameters.containsKey("projectlist"))
         {
             projectList = (String) parameters.get("projectlist");
+        }
+
+        if (parameters.containsKey("usetlk"))
+        {
+            String useTLKStr = (String) parameters.get("usetlk");
+            useTLK = Boolean.parseBoolean(useTLKStr.toLowerCase());
         }
 
         compression = CompressionAlgorithm.DEFAULT;

--- a/DataAccess/src/test/java/org/hpccsystems/spark/HpccRelationIntegrationTest.java
+++ b/DataAccess/src/test/java/org/hpccsystems/spark/HpccRelationIntegrationTest.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.TreeMap;
 
+import javax.xml.validation.Schema;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.rdd.RDD;
@@ -27,6 +29,7 @@ import org.apache.spark.sql.sources.StringStartsWith;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.hpccsystems.dfs.client.CompressionAlgorithm;
 import org.hpccsystems.spark.datasource.HpccOptions;
 import org.hpccsystems.spark.datasource.HpccRelation;
 import org.junit.After;
@@ -95,6 +98,56 @@ public class HpccRelationIntegrationTest extends BaseIntegrationTest
 
         RDD<Row> rdd = hpccRelation.buildScan(new String[]{"key"}, supportedSparkFilters);
         Assert.assertTrue("Unexpected filter result count", rdd.count() == 1);
+    }
+
+    @Test
+    public void testOptionsPassThrough() throws Exception
+    {
+        SparkSession spark = getOrCreateSparkSession();
+        SQLContext sqlcontext = new SQLContext(spark);
+
+        TreeMap<String, String> paramTreeMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        String url = getHPCCClusterURL();
+        String user = "user";
+        String pass = "pass";
+        paramTreeMap.put("host", url);
+        paramTreeMap.put("username", user);
+        paramTreeMap.put("password", pass);
+
+        String path = "spark::test::integer_kv";
+        paramTreeMap.put("path", path);
+
+        paramTreeMap.put("cluster", getThorCluster());
+        paramTreeMap.put("useTLK", "True"); // Defaults to false, also should be case insensitive
+        paramTreeMap.put("fileAccessTimeout", "120000");
+        paramTreeMap.put("limitPerFilePart", "100");
+
+        String projectList = "key, value";
+        paramTreeMap.put("projectList", projectList);
+
+        String filterStr = "key > 5";
+        paramTreeMap.put("filter", filterStr);
+
+        paramTreeMap.put("compression", "LZ4");
+
+        HpccOptions hpccopts = new HpccOptions(paramTreeMap);
+
+        // These options don't currently have accessors in HPCCFile
+        Assert.assertEquals(url, hpccopts.connectionInfo.getUrl());
+        Assert.assertEquals(user, hpccopts.connectionInfo.getUserName());
+        Assert.assertEquals(pass, hpccopts.connectionInfo.getPassword());
+        Assert.assertEquals(filterStr, hpccopts.filterString);
+        Assert.assertEquals(CompressionAlgorithm.LZ4, hpccopts.compression);
+
+        HpccRelation hpccRelation = new HpccRelation(sqlcontext, hpccopts);
+
+        Assert.assertEquals(true, hpccRelation.getFile().getUseTLK());
+        Assert.assertEquals(getThorCluster(), hpccRelation.getFile().getTargetfilecluster());
+        Assert.assertEquals(path, hpccRelation.getFile().getFileName());
+        Assert.assertEquals(120000, hpccRelation.getFile().getFileAccessExpirySecs());
+        Assert.assertEquals(100, hpccRelation.getFile().getFilePartRecordLimit());
+        Assert.assertEquals(projectList, hpccRelation.getFile().getProjectList());
     }
 
     @Test

--- a/Examples/PySparkExample.ipynb
+++ b/Examples/PySparkExample.ipynb
@@ -147,7 +147,8 @@
     "- **Cluster**: The name of the underlying Thor cluster storage plane, this will change based on the target HPCC Systems cluster configuration, but will default to \"mythor\" on bare-metal and \"data\" on containerized systems.\n",
     "- **Path**: The file path for the dataset within the HPCC Systems cluster\n",
     "- **limitPerFilePart**: *Optional* Limit on the number of records to be read per file part / partition within the HPCC Systems dataset.\n",
-    "- **projectList**: *Optional* The columns that should be read from the HPCC Systems dataset.\n"
+    "- **projectList**: *Optional* The columns that should be read from the HPCC Systems dataset.\n",
+    "- **useTLK** *Optional* Defaults to false, determines whether or not the TLK (Top Level Key) should be used when reading index files. \n"
    ]
   },
   {
@@ -161,6 +162,7 @@
     "                         host=\"http://127.0.0.1:8010\",\n",
     "                         username=\"\",\n",
     "                         password=\"\",\n",
+    "                         useTLK=\"false\",\n",
     "                         cluster=\"mythor\",\n",
     "                         path=\"spark::test::dataset\",\n",
     "                         limitPerFilePart=100,\n",

--- a/README.md
+++ b/README.md
@@ -23,24 +23,20 @@
 </table>
 
 # Spark-HPCC
-Spark classes for HPCC Systems/ Spark interoperability
-
-This repository is comprised of two projects, DataAccess and Examples.
+Spark classes for HPCC Systems / Spark interoperability
 
 ### DataAccess
 The DataAccess project contains the classes which expose distributed
 streaming of HPCC based data via Spark constructs. In addition,
 the HPCC data is exposed as a Dataframe for the convenience of the Spark developer.
 
-#### Dependancies
+### Dependencies
 The spark-hpcc target jar does not package any of the Spark libraries it depends on.
 If using a standard Spark submission pipeline such as spark-submit these dependencies will be provided as part of the Spark installation.
 However, if your pipeline executes a jar directly you may need to add the Spark libraries from your $SPARK_HOME to the classpath.
 
-### Examples
-The Examples project contains examples in Scala for
-using HPCC THOR cluster based data in a Machine
-Learning application.
+### Examples & Documentation
+See: [Examples](https://github.com/hpcc-systems/Spark-HPCC/tree/master/Examples) for example usage of the connector as well as API documentation for the reading and writing APIs.
 
 ## Please note:
 ##### As reported by github:


### PR DESCRIPTION
- Exposed UseTLK option to Spark-HPCC connector
- Added example and description of use to Examples PySpark document
- Added a test case for options pass through

Signed-off-by: James McMullan James.McMullan@lexisnexis.com