### PR TITLE
HPCC4J-625 SparkHPCC: Path support Databricks URI requirements

### DIFF
--- a/DataAccess/src/main/java/org/hpccsystems/spark/datasource/HpccOptions.java
+++ b/DataAccess/src/main/java/org/hpccsystems/spark/datasource/HpccOptions.java
@@ -47,6 +47,13 @@ public class HpccOptions
         if (parameters.containsKey("path"))
         {
             fileName = (String) parameters.get("path");
+
+            // Remove leading forward slashes
+            fileName = fileName.replaceAll("^/+", "");
+
+            String[] filePathParts = fileName.split("/|::");
+            fileName = String.join("::", filePathParts);
+
         }
 
         if (parameters.containsKey("cluster"))

--- a/Examples/PySparkExample.ipynb
+++ b/Examples/PySparkExample.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "id": "7103a826",
    "metadata": {},
    "outputs": [],
@@ -51,10 +51,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 2,
    "id": "44c6d7e4",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 0:>                                                          (0 + 1) / 1]\r",
+      "\r",
+      "                                                                                \r"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -62,26 +72,26 @@
       "+---+----------+\n",
       "|key|      fill|\n",
       "+---+----------+\n",
-      "|  0|2093710133|\n",
-      "|  1|8298950336|\n",
-      "|  2|8184283203|\n",
-      "|  3|7991449698|\n",
-      "|  4|2230822419|\n",
-      "|  5|6088498312|\n",
-      "|  6|2125960683|\n",
-      "|  7|9243328381|\n",
-      "|  8|6184681638|\n",
-      "|  9|6103701586|\n",
-      "| 10|1113644174|\n",
-      "| 11|6422865225|\n",
-      "| 12|3522318506|\n",
-      "| 13|5734827156|\n",
-      "| 14|7946567617|\n",
-      "| 15|6700616122|\n",
-      "| 16|5306580724|\n",
-      "| 17|9696286149|\n",
-      "| 18|4157652341|\n",
-      "| 19|3429216958|\n",
+      "|  0|8802828259|\n",
+      "|  1|6769815762|\n",
+      "|  2|3802883209|\n",
+      "|  3|7410875502|\n",
+      "|  4| 135941891|\n",
+      "|  5|2166775522|\n",
+      "|  6| 883758744|\n",
+      "|  7|3540920239|\n",
+      "|  8|  20735769|\n",
+      "|  9|4435630331|\n",
+      "| 10|2674809260|\n",
+      "| 11|2527618309|\n",
+      "| 12|9667830781|\n",
+      "| 13|8674197252|\n",
+      "| 14|2973016826|\n",
+      "| 15|7810363123|\n",
+      "| 16|3267854158|\n",
+      "| 17|9341494262|\n",
+      "| 18|8715303091|\n",
+      "| 19|7096204106|\n",
       "+---+----------+\n",
       "only showing top 20 rows\n",
       "\n"
@@ -109,14 +119,14 @@
     "- **Host**: The URL of an ESP running on the target HPCC Systems cluster.\n",
     "- **Username / Password**: Credentials for an HPCC Systems cluster user, can be empty or null if security isn't enabled on the target cluster.\n",
     "- **Cluster**: The name of the underlying Thor cluster storage plane, this will change based on the target HPCC Systems cluster configuration, but will default to \"mythor\" on bare-metal and \"data\" on containerized systems.\n",
-    "- **Path**: The file path for the dataset within the HPCC Systems cluster\n",
+    "- **Path**: The file path for the dataset within the HPCC Systems cluster. **Note** Spark-HPCC versions [9.2.110, 9.4.84, 9.6.36, 9.8.10] and above allows for paths to be defined with \"/\" path delimiter instead of the HPCC \"::\" delimiter this fixes URI formatting errors on Databricks.\n",
     "- **Compression**: The compression algorithm to use when writing the file to the HPCC Systems cluster.\n",
     "    - Options: *[default, none, lz4, flz, lzw]*\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "05ba80cb",
    "metadata": {},
    "outputs": [],
@@ -127,7 +137,8 @@
     "              username=\"\",\n",
     "              password=\"\",\n",
     "              cluster=\"mythor\",\n",
-    "              path=\"spark::test::dataset\",\n",
+    "              #path=\"spark::test::dataset\", Old path format not supported on Databricks\n",
+    "              path=\"/spark/test/dataset\",\n",
     "              compression=\"default\")"
    ]
   },
@@ -145,14 +156,14 @@
     "- **Host**: The URL of an ESP running on the target HPCC Systems cluster.\n",
     "- **Username / Password**: Credentials for an HPCC Systems cluster user, can be empty or null if security isn't enabled on the target cluster.\n",
     "- **Cluster**: The name of the underlying Thor cluster storage plane, this will change based on the target HPCC Systems cluster configuration, but will default to \"mythor\" on bare-metal and \"data\" on containerized systems.\n",
-    "- **Path**: The file path for the dataset within the HPCC Systems cluster\n",
+    "- **Path**: The file path for the dataset within the HPCC Systems cluster. **Note** Spark-HPCC versions [9.2.110, 9.4.84, 9.6.36, 9.8.10] and above allows for paths to be defined with \"/\" path delimiter instead of the HPCC \"::\" delimiter this fixes URI formatting errors on Databricks.\n",
     "- **limitPerFilePart**: *Optional* Limit on the number of records to be read per file part / partition within the HPCC Systems dataset.\n",
     "- **projectList**: *Optional* The columns that should be read from the HPCC Systems dataset.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "e8d49d8f",
    "metadata": {},
    "outputs": [],
@@ -162,14 +173,15 @@
     "                         username=\"\",\n",
     "                         password=\"\",\n",
     "                         cluster=\"mythor\",\n",
-    "                         path=\"spark::test::dataset\",\n",
+    "                         #path=\"spark::test::dataset\", Old path format not supported on Databricks\n",
+    "                         path=\"/spark/test/dataset\",\n",
     "                         limitPerFilePart=100,\n",
     "                         projectList=\"key, fill\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "id": "c16a758c",
    "metadata": {},
    "outputs": [
@@ -180,26 +192,26 @@
       "+---+----------+\n",
       "|key|      fill|\n",
       "+---+----------+\n",
-      "|  0|2093710133|\n",
-      "|  1|8298950336|\n",
-      "|  2|8184283203|\n",
-      "|  3|7991449698|\n",
-      "|  4|2230822419|\n",
-      "|  5|6088498312|\n",
-      "|  6|2125960683|\n",
-      "|  7|9243328381|\n",
-      "|  8|6184681638|\n",
-      "|  9|6103701586|\n",
-      "| 10|1113644174|\n",
-      "| 11|6422865225|\n",
-      "| 12|3522318506|\n",
-      "| 13|5734827156|\n",
-      "| 14|7946567617|\n",
-      "| 15|6700616122|\n",
-      "| 16|5306580724|\n",
-      "| 17|9696286149|\n",
-      "| 18|4157652341|\n",
-      "| 19|3429216958|\n",
+      "|  0|8802828259|\n",
+      "|  1|6769815762|\n",
+      "|  2|3802883209|\n",
+      "|  3|7410875502|\n",
+      "|  4| 135941891|\n",
+      "|  5|2166775522|\n",
+      "|  6| 883758744|\n",
+      "|  7|3540920239|\n",
+      "|  8|  20735769|\n",
+      "|  9|4435630331|\n",
+      "| 10|2674809260|\n",
+      "| 11|2527618309|\n",
+      "| 12|9667830781|\n",
+      "| 13|8674197252|\n",
+      "| 14|2973016826|\n",
+      "| 15|7810363123|\n",
+      "| 16|3267854158|\n",
+      "| 17|9341494262|\n",
+      "| 18|8715303091|\n",
+      "| 19|7096204106|\n",
       "+---+----------+\n",
       "only showing top 20 rows\n",
       "\n"
@@ -209,14 +221,6 @@
    "source": [
     "readDf.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6186315a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -235,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Allowed path used in Datasource API to formatted as URIs to fix Databricks issue

Signed-off-by: James McMullan James.McMullan@lexisnexis.com